### PR TITLE
Allow inheritance of _init from more than one level up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.x.x (upcoming)
+
+## Fixes
+
+  - In `pl.class`, `_init` can now be inherited from grandparent (or older ancestor) classes. (#289)
+
 ## 1.8.0 (2020-08-05)
 
 ### New features

--- a/lua/pl/class.lua
+++ b/lua/pl/class.lua
@@ -30,6 +30,8 @@ local function call_ctor (c,obj,...)
                 call_ctor(parent_with_init,obj,...)
             end)
         end
+    else
+        rawset(obj,'super',nil)
     end
     local res = init(obj,...)
     rawset(obj,'super',nil)

--- a/lua/pl/class.lua
+++ b/lua/pl/class.lua
@@ -31,10 +31,15 @@ local function call_ctor (c,obj,...)
             end)
         end
     else
+        -- Without this, calling super() where none exists will sometimes loop and stack overflow
         rawset(obj,'super',nil)
     end
+
     local res = init(obj,...)
-    rawset(obj,'super',nil)
+    if parent_with_init then -- If this execution of call_ctor set a super, unset it
+        rawset(obj,'super',nil)
+    end
+
     return res
 end
 

--- a/tests/test-class.lua
+++ b/tests/test-class.lua
@@ -47,6 +47,36 @@ c = C()
 c:foo()
 
 asserteq(c,{a=1,b=2,c=3,eee=1})
+
+-- test indirect inherit
+
+D = class(C)
+
+E = class(D)
+
+function E:_init ()
+    self:super()
+    self.e = 4
+end
+
+function E:foo ()
+    -- recommended way to call inherited version of method...
+    self.eeee = 5
+    C.foo(self)
+end
+
+F = class(E)
+
+function F:_init ()
+    self:super()
+    self.f = 6
+end
+
+f = F()
+f:foo()
+
+asserteq(f,{a=1,b=2,c=3,eee=1,e=4,eeee=5,f=6})
+
 --- class methods!
 assert(c:is_a(C))
 assert(c:is_a(B))

--- a/tests/test-class.lua
+++ b/tests/test-class.lua
@@ -27,6 +27,10 @@ function B:foo ()
     self.eee = 1
 end
 
+function B:foo2 ()
+    self.g = 8
+end
+
 asserteq(B(),{a=1,b=2})
 
 -- can continue this chain
@@ -74,8 +78,49 @@ end
 
 f = F()
 f:foo()
+f:foo2() -- Test : invocation inherits this function from all the way up in B
 
-asserteq(f,{a=1,b=2,c=3,eee=1,e=4,eeee=5,f=6})
+asserteq(f,{a=1,b=2,c=3,eee=1,e=4,eeee=5,f=6,g=8})
+
+-- Test that inappropriate calls to super() fail gracefully
+
+G = class() -- Class with no init
+
+H = class(G) -- Class with an init that wrongly calls super()
+
+function H:_init()
+    self:super() -- Notice: G has no _init
+end
+
+I = class(H) -- Inherits the init with a bad super
+J = class(I) -- Grandparent-inits the init with a bad super
+
+K = class(J) -- Has an init, which calls the init with a bad super
+
+function K:_init()
+    self:super()
+end
+
+local function createG()
+    return G()
+end
+
+local function createH() -- Wrapper function for pcall
+    return H()
+end
+
+local function createJ()
+    return J()
+end
+
+local function createK()
+    return K()
+end
+
+assert(pcall(createG)) -- Should succeed
+assert(not pcall(createH)) -- These three should fail
+assert(not pcall(createJ))
+assert(not pcall(createK))
 
 --- class methods!
 assert(c:is_a(C))


### PR DESCRIPTION
Addresses #288. My smoke test is

    lua5.1 -e 'class = require("pl.class") class.A() function A:_init(x) print("A", x) end A(3) class.B(A) B(4) class.C(B) C(5) class.D(C) function D:_init(x) print("D", x) end D(6) class.E(D) E(7) class.F(E) function F:_init(x) print("F", x, "THEN") self:super(x) end F(8) class.G(F) G(9) class.H(G) function H:_init(x) print("H", x, "THEN") self:super(x) end H(10) class.I(H) I(11)'

Explanation:

Currently _init is exempted from "fat inheritance", and _init inheritance works by a strange workaround where the base class exactly one level up is checked for _init at constructor time. This appears to be done so that :super() can work properly, but it means that _init cannot be inherited from a grandparent.

This patch adds a _parent_with_init field to all relevant classes which points to the most recent ancestor with an _init implementation. This simplifies both __call and _class and might actually be a performance improvement (it removes a loop).