### PR TITLE
pl.dir: convert dir.walk from coroutines to iterators, take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
+## unreleased
+
+ - fix: dir.walk [#350](https://github.com/lunarmodules/Penlight/pull/350)
+
+
 ## 1.9.1 (2020-09-24)
 
  - released to superseed the 1.9.0 version which was retagged in git after some


### PR DESCRIPTION
I missed converting `dir.walk` on my previous PR, sorry about that! Thanks @Tieske for jumping in and making a conversion, but that approach doesn't work — I did not dissect your algorithm fully because it was definitely faster to redo it from scratch than to debug the existing one, but I noticed you were not not keeping track of a stack of pending tasks. Coroutine-based algorithms for iterators effectively exploit the call stack as a data structure; when converting them to non-coroutine-based, you need to keep that data structure elsewhere.

I have not tested this extensively, but it passes both the `tests` and `examples` suites. I hadn't noticed the `examples` suite at all when I submitted #344 — thanks @alerque for the ping about it.

Fixes #348.