### PR TITLE
Break out linting into its own CI workflow

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -18,4 +18,6 @@ jobs:
     - name: Setup dependencies
       run: luarocks install luacheck
     - name: Run Code Linter
-      run: luacheck .
+      run: |
+        luacheck .
+        luarocks lint *.rockspec

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,0 +1,21 @@
+name: Luacheck
+
+on: [push, pull_request]
+
+jobs:
+  luacheck:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Lua
+      uses: leafo/gh-actions-lua@v6
+      with:
+        luaVersion: 5.4
+    - name: Setup Lua Rocks
+      uses: leafo/gh-actions-luarocks@v2
+    - name: Setup dependencies
+      run: luarocks install luacheck
+    - name: Run Code Linter
+      run: luacheck .

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -11,6 +11,12 @@ not_globals = {
     "table.getn",
 }
 
+include_files = {
+  "**/*.lua",
+  "*.rockspec",
+  ".luacheckrc",
+  "config.lp",
+}
 
 exclude_files = {
     "tests/*.lua",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -15,8 +15,13 @@ not_globals = {
 exclude_files = {
     "tests/*.lua",
     "tests/**/*.lua",
+    -- Travis Lua environment
     "here/*.lua",
     "here/**/*.lua",
+    -- GH Actions Lua Environment
+    ".lua",
+    ".luarocks",
+    ".install",
 
     -- TODO: fix these files
     "examples/symbols.lua",

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,12 @@ before_install:
   - pip install hererocks
   - hererocks here -r^ --$LUA
   - source here/bin/activate
-  - luarocks install luacheck
   - luarocks install luacov-coveralls
 
 install:
   - luarocks make
 
 script:
-  - luacheck .
   - lua run.lua tests --luacov
   - lua run.lua examples
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Travis build status](https://img.shields.io/travis/lunarmodules/Penlight?logo=Travis)](https://travis-ci.org/lunarmodules/Penlight)
 [![AppVeyor build status](https://img.shields.io/appveyor/build/Tieske/penlight-ta1gi?logo=appveyor)](https://ci.appveyor.com/project/Tieske/penlight-ta1gi/branch/master)
 [![Coveralls code coverage](https://img.shields.io/coveralls/github/lunarmodules/Penlight?logo=coveralls)](https://coveralls.io/github/lunarmodules/Penlight)
+[![Luacheck](https://github.com/lunarmodules/Penlight/workflows/Luacheck/badge.svg)](https://github.com/lunarmodules/Penlight/actions)
 
 ## Why a new set of libraries?
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Penlight Lua Libraries
 
-[![Travis-CI Status](https://travis-ci.org/lunarmodules/Penlight.svg?branch=master)](https://travis-ci.org/lunarmodules/Penlight)
-[![Coverage Status](https://coveralls.io/repos/github/lunarmodules/Penlight/badge.svg)](https://coveralls.io/github/lunarmodules/Penlight)
-[![AppVeyor status](https://ci.appveyor.com/api/projects/status/4jxg4ruktwi00up2/branch/master?svg=true)](https://ci.appveyor.com/project/Tieske/penlight-ta1gi/branch/master)
-
-
+[![Travis build status](https://img.shields.io/travis/lunarmodules/Penlight?logo=Travis)](https://travis-ci.org/lunarmodules/Penlight)
+[![AppVeyor build status](https://img.shields.io/appveyor/build/Tieske/penlight-ta1gi?logo=appveyor)](https://ci.appveyor.com/project/Tieske/penlight-ta1gi/branch/master)
+[![Coveralls code coverage](https://img.shields.io/coveralls/github/lunarmodules/Penlight?logo=coveralls)](https://coveralls.io/github/lunarmodules/Penlight)
 
 ## Why a new set of libraries?
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,6 @@ before_build:
   - pip install hererocks
   - hererocks here --%LUA% -rlatest
   - call here\bin\activate
-  - luarocks install luacheck
   - "if \"%LUA%\"==\"lua 5.4\" ( luarocks install bit32 )"
   - luarocks install luacov-coveralls
 
@@ -26,7 +25,6 @@ build_script:
   - luarocks make
 
 test_script:
-  - luacheck .
   - lua run.lua tests --luacov
   - lua run.lua examples
 


### PR DESCRIPTION
Luacheck isn't platform or Lua version dependant and doesn't need to run as part of every job. Having it in a separate workflow by itself will be simpler, faster, and also provide its status independently of other tests making it easier to review test failures.