### PR TITLE
Tweak rockspec to normalize fields, callout spec version, etc.

### DIFF
--- a/penlight-dev-1.rockspec
+++ b/penlight-dev-1.rockspec
@@ -1,6 +1,6 @@
 rockspec_format = "3.0"
 package = "penlight"
-version = "scm-3"
+version = "dev-1"
 
 source = {
   url = "git://github.com/lunarmodules/Penlight.git",

--- a/penlight-scm-3.rockspec
+++ b/penlight-scm-3.rockspec
@@ -1,3 +1,4 @@
+rockspec_format = "3.0"
 package = "penlight"
 version = "scm-3"
 
@@ -8,18 +9,20 @@ source = {
 
 description = {
   summary = "Lua utility libraries loosely based on the Python standard libraries",
-  homepage = "https://lunarmodules.github.io/Penlight",
-  license = "MIT/X11",
-  maintainer = "thijs@thijsschreijer.nl",
   detailed = [[
       Penlight is a set of pure Lua libraries focusing on input data handling
       (such as reading configuration files), functional programming
       (such as map, reduce, placeholder expressions,etc), and OS path management.
       Much of the functionality is inspired by the Python standard libraries.
-    ]]
+    ]],
+  license = "MIT/X11",
+  homepage = "https://lunarmodules.github.io/Penlight",
+  issues_url = "https://github.com/lunarmodules/Penlight/issues",
+  maintainer = "thijs@thijsschreijer.nl",
 }
 
 dependencies = {
+  "lua >= 5.1",
   "luafilesystem"
 }
 

--- a/penlight-scm-3.rockspec
+++ b/penlight-scm-3.rockspec
@@ -12,10 +12,11 @@ description = {
   license = "MIT/X11",
   maintainer = "thijs@thijsschreijer.nl",
   detailed = [[
-Penlight is a set of pure Lua libraries for making it easier to work with common tasks like
-iterating over directories, reading configuration files and the like. Provides functional operations
-on tables and sequences.
-]]
+      Penlight is a set of pure Lua libraries focusing on input data handling
+      (such as reading configuration files), functional programming
+      (such as map, reduce, placeholder expressions,etc), and OS path management.
+      Much of the functionality is inspired by the Python standard libraries.
+    ]]
 }
 
 dependencies = {


### PR DESCRIPTION
~~Only the last commit here is relevant, all the others are part of #355.~~

This is on hold until...

- [x] Sometime after #355 is merged (on which it is based)
- ~~[ ] Immediately before a tagged release so the SCM rockspec rename doesn't cause issues between releases~~
- [x] Somebody confirms that the addition of the Lua VM version is valid for moonscript
- [x] We find the docs and what is and isn't allowed in the description and squash the fixup commit