### PR TITLE
fix(dir.rmtree) remove symlinks without following

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -10,11 +10,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Setup Lua
-      uses: leafo/gh-actions-lua@v6
+      uses: leafo/gh-actions-lua@v8
       with:
         luaVersion: 5.4
     - name: Setup Lua Rocks
-      uses: leafo/gh-actions-luarocks@v2
+      uses: leafo/gh-actions-luarocks@v4
     - name: Setup dependencies
       run: luarocks install luacheck
     - name: Run Code Linter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    [#360](https://github.com/lunarmodules/Penlight/pull/360)
  - feat: `permute.list_table` generate table with different sets of values
    [#360](https://github.com/lunarmodules/Penlight/pull/360)
- - feat: deprecation functionality `utils.raise_deprecation` [#361](https://github.com/lunarmodules/Penlight/pull/361)
+ - feat: deprecation functionality `utils.raise_deprecation`
+   [#361](https://github.com/lunarmodules/Penlight/pull/361)
+ - fix: `dir.rmtree` failed to remove symlinks to directories
+   [#365](https://github.com/lunarmodules/Penlight/pull/365)
 
 
 ## 1.9.1 (2020-09-27)


### PR DESCRIPTION
`rmtree` would fail when an entry somewhere in the tree was a symlink to another directory.
Links to files would be deleted, but links to directories would cause an error.

This PR ensures that symlinks to directories are also deleted in the same way.

Also adds tests.