### PR TITLE
fix issue of parse_args not handling ':' in options correctly

### DIFF
--- a/lua/pl/app.lua
+++ b/lua/pl/app.lua
@@ -255,9 +255,10 @@ function app.parse_args (args,flags_with_values, flags_valid)
                 i = i + 1
             else
                 -- a value can also be indicated with = or :
-                local var,val =  utils.splitv (v,'[=:]')
-                var = var or v
-                val = val or true
+                local parts =  utils.split (v,'[=:]', false, 2)
+                var = parts[1] or v
+                val = parts[2] or true
+
                 if not is_long then
                     if #var > 1 then
                         if var:find '.%d+' then -- short flag, number value

--- a/lua/pl/app.lua
+++ b/lua/pl/app.lua
@@ -256,8 +256,8 @@ function app.parse_args (args,flags_with_values, flags_valid)
             else
                 -- a value can also be indicated with = or :
                 local parts =  utils.split (v,'[=:]', false, 2)
-                var = parts[1] or v
-                val = parts[2] or true
+                local var = parts[1] or v
+                local val = parts[2] or true
 
                 if not is_long then
                     if #var > 1 then


### PR DESCRIPTION
If an option contains ':', the parsed value is truncated 
test:
```
--package.path  = '/home/hel/Penlight/lua/?.lua' .. ';' .. package.path
app=require 'pl.app'
pretty=require 'pl.pretty'
my_args = {'hello', '--flip=this', '--flop=that:zzz'}
args = app.parse_args(my_args)
print(pretty.write(args))
```

prints:
```
{
  flop = "that",
  flip = "this"
}
```

flop should be 'that:zzz'
Note: this is my first pull request ever, sure hope it works out :-)
