### PR TITLE
fix(dir) makepath failed to create top-level directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ deprecation policy.
 
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
-## unreleased
+## 1.10.0 unreleased
 
  - deprecate: `permute.iter`, renamed to `permute.order_iter` (removal later)
    [#360](https://github.com/lunarmodules/Penlight/pull/360)
@@ -30,6 +30,9 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    [#368](https://github.com/lunarmodules/Penlight/pull/368)
  - fix: `app.parse` now correctly parses values containing '=' or ':'
    [#373](https://github.com/lunarmodules/Penlight/pull/373)
+ - fix: `dir.makepath` failed to create top-level directories
+   [#372](https://github.com/lunarmodules/Penlight/pull/372)
+
 
 ## 1.9.2 (2020-09-27)
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ In scope of the version:
 
 Not in scope of the version:
  * Documentation
+ * Error messages (textual changes)
  * Deprecation warnings (by default to `stderr`)
 
 ### Deprecating functionality

--- a/lua/pl/dir.lua
+++ b/lua/pl/dir.lua
@@ -349,42 +349,44 @@ function dir.rmtree(fullpath)
     return true
 end
 
-local dirpat
-if path.is_windows then
-    dirpat = '(.+)\\[^\\]+$'
-else
-    dirpat = '(.+)/[^/]+$'
-end
 
-local _makepath
-function _makepath(p)
-    -- windows root drive case
-    if p:find '^%a:[\\]*$' then
-        return true
-    end
-   if not path.isdir(p) then
-    local subp = p:match(dirpat)
-    local ok, err = _makepath(subp)
-    if not ok then return nil, err end
-    return mkdir(p)
-   else
-    return true
-   end
-end
+do
+  local dirpat
+  if path.is_windows then
+      dirpat = '(.+)\\[^\\]+$'
+  else
+      dirpat = '(.+)/[^/]+$'
+  end
 
---- create a directory path.
--- This will create subdirectories as necessary!
--- @string p A directory path
--- @return true on success, nil + errormsg on failure
--- @raise failure to create
-function dir.makepath (p)
-    assert_string(1,p)
-    if path.is_windows then
-        p = p:gsub("/", "\\")
-    end
-    return _makepath(path.abspath(p))
-end
+  local _makepath
+  function _makepath(p)
+      -- windows root drive case
+      if p:find '^%a:[\\]*$' then
+          return true
+      end
+      if not path.isdir(p) then
+          local subp = p:match(dirpat)
+          local ok, err = _makepath(subp)
+          if not ok then return nil, err end
+          return mkdir(p)
+      else
+          return true
+      end
+  end
 
+  --- create a directory path.
+  -- This will create subdirectories as necessary!
+  -- @string p A directory path
+  -- @return true on success, nil + errormsg on failure
+  -- @raise failure to create
+  function dir.makepath (p)
+      assert_string(1,p)
+      if path.is_windows then
+          p = p:gsub("/", "\\")
+      end
+      return _makepath(path.abspath(p))
+  end
+end
 
 --- clone a directory tree. Will always try to create a new directory structure
 -- if necessary.

--- a/lua/pl/dir.lua
+++ b/lua/pl/dir.lua
@@ -366,8 +366,10 @@ do
       end
       if not path.isdir(p) then
           local subp = p:match(dirpat)
-          local ok, err = _makepath(subp)
-          if not ok then return nil, err end
+          if subp then
+            local ok, err = _makepath(subp)
+            if not ok then return nil, err end
+          end
           return mkdir(p)
       else
           return true

--- a/lua/pl/path.lua
+++ b/lua/pl/path.lua
@@ -32,6 +32,13 @@ local link_attrib = lfs.symlinkattributes
 
 local path = {}
 
+local function err_func(name, param, err, code)
+  if code == nil then
+    return ("%s failed for '%s': %s"):format(tostring(name), tostring(param), tostring(err))
+  end
+  return ("%s failed for '%s': %s (code %s)"):format(tostring(name), tostring(param), tostring(err), tostring(code))
+end
+
 --- Lua iterator over the entries of a given directory.
 -- Implicit link to [`luafilesystem.dir`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
 -- @function dir
@@ -40,34 +47,70 @@ path.dir = lfs.dir
 --- Creates a directory.
 -- Implicit link to [`luafilesystem.mkdir`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
 -- @function mkdir
-path.mkdir = lfs.mkdir
+path.mkdir = function(d)
+  local ok, err, code = lfs.mkdir(d)
+  if not ok then
+    return ok, err_func("mkdir", d, err, code), code
+  end
+  return ok, err, code
+end
 
 --- Removes a directory.
 -- Implicit link to [`luafilesystem.rmdir`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
 -- @function rmdir
-path.rmdir = lfs.rmdir
+path.rmdir = function(d)
+  local ok, err, code = lfs.rmdir(d)
+  if not ok then
+    return ok, err_func("rmdir", d, err, code), code
+  end
+  return ok, err, code
+end
 
 --- Gets attributes.
 -- Implicit link to [`luafilesystem.attributes`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
 -- @function attrib
-path.attrib = attrib
+path.attrib = function(d, r)
+  local ok, err, code = attrib(d, r)
+  if not ok then
+    return ok, err_func("attrib", d, err, code), code
+  end
+  return ok, err, code
+end
 
 --- Get the working directory.
 -- Implicit link to [`luafilesystem.currentdir`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
 -- @function currentdir
-path.currentdir = currentdir
+path.currentdir = function(d)
+  local ok, err, code = currentdir(d)
+  if not ok then
+    return ok, err_func("currentdir", d, err, code), code
+  end
+  return ok, err, code
+end
 
 --- Gets symlink attributes.
 -- Implicit link to [`luafilesystem.symlinkattributes`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
 -- @function link_attrib
-path.link_attrib = link_attrib
+path.link_attrib = function(d, r)
+  local ok, err, code = link_attrib(d, r)
+  if not ok then
+    return ok, err_func("link_attrib", d, err, code), code
+  end
+  return ok, err, code
+end
 
 --- Changes the working directory.
 -- On Windows, if a drive is specified, it also changes the current drive. If
 -- only specifying the drive, it will only switch drive, but not modify the path.
 -- Implicit link to [`luafilesystem.chdir`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
 -- @function chdir
-path.chdir = lfs.chdir
+path.chdir = function(d)
+  local ok, err, code = lfs.chdir(d)
+  if not ok then
+    return ok, err_func("chdir", d, err, code), code
+  end
+  return ok, err, code
+end
 
 --- is this a directory?
 -- @string P A file path


### PR DESCRIPTION
also wraps LFS functions to provide more descriptive error messages