### PR TITLE
fix(path) currentdir does not accept parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
 ## 1.10.x unreleased
  - fix: `stringx.strip` behaved badly with string lengths > 200
    [#382](https://github.com/lunarmodules/Penlight/pull/382)
+ - fix: `path.currentdir` now takes no arguments and calls `lfs.currentdir` without argument
+   [#383](https://github.com/lunarmodules/Penlight/pull/383)
 
 
 ## 1.10.0 (2021-04-27)

--- a/lua/pl/path.lua
+++ b/lua/pl/path.lua
@@ -33,10 +33,15 @@ local link_attrib = lfs.symlinkattributes
 local path = {}
 
 local function err_func(name, param, err, code)
-  if code == nil then
-    return ("%s failed for '%s': %s"):format(tostring(name), tostring(param), tostring(err))
+  local ret = ("%s failed"):format(tostring(name))
+  if param ~= nil then
+    ret = ret .. (" for '%s'"):format(tostring(param))
   end
-  return ("%s failed for '%s': %s (code %s)"):format(tostring(name), tostring(param), tostring(err), tostring(code))
+  ret = ret .. (": %s"):format(tostring(err))
+  if code ~= nil then
+    ret = ret .. (" (code %s)"):format(tostring(code))
+  end
+  return ret
 end
 
 --- Lua iterator over the entries of a given directory.
@@ -80,10 +85,10 @@ end
 --- Get the working directory.
 -- Implicit link to [`luafilesystem.currentdir`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
 -- @function currentdir
-path.currentdir = function(d)
-  local ok, err, code = currentdir(d)
+path.currentdir = function()
+  local ok, err, code = currentdir()
   if not ok then
-    return ok, err_func("currentdir", d, err, code), code
+    return ok, err_func("currentdir", nil, err, code), code
   end
   return ok, err, code
 end


### PR DESCRIPTION
I'm using an alternative LuaFileSystem implementation that checks num of args. It now errors with pl 1.10 because `pl.path.currentdir` is calling `lfs.currentdir` with 1 argument, `nil`.

According to [LuaFileSystem Reference](https://keplerproject.github.io/luafilesystem/manual.html) `lfs.currentdir` does not accept any argument. This PR removes the argument in both `pl.path.currentdir` and the call to `lfs.currentdir`.