### PR TITLE
Allow negative number arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
 ## 1.12.0 (unreleased)
  - feat: `utils.npairs` added. An iterator with a range that honours the `n` field
    [#387](https://github.com/lunarmodules/Penlight/pull/387)
+ - fix: `lapp.process_options_string` now treats negative numbers as arguments instead of flags
+   [#389](https://github.com/lunarmodules/Penlight/pull/389)
 
 ## 1.11.0 (2021-08-18)
 

--- a/lua/pl/lapp.lua
+++ b/lua/pl/lapp.lua
@@ -352,7 +352,7 @@ function lapp.process_options_string(str,args)
             end
         end
         -- look for a flag, -<short flags> or --<long flag>
-        if not end_of_flags and (match('--$S{long}',theArg,res) or match('-$S{short}',theArg,res)) then
+        if not end_of_flags and (match('--$S{long}',theArg,res) or (match('-$S{short}',theArg,res) and not string.match(theArg, "^-%d"))) then
             if res.long then -- long option
                 parm = check_parm(res.long)
             elseif #res.short == 1 or is_flag(res.short) then

--- a/tests/test-lapp.lua
+++ b/tests/test-lapp.lua
@@ -147,6 +147,19 @@ check (false_flag,{'-g','-f'},{f=false,g=true})
 check (false_flag,{'-g','--'},{f=true,g=true})
 check (false_flag,{'-g','--','-a','frodo'},{f=true,g=true; '-a','frodo'})
 
+-- check that negative number arugments are accepted
+local negative_argument = [[
+    -f, --flag      short flag
+    <val> (number)  the argument
+]]
+
+check (negative_argument, {'-2'}, {val=-2, flag=false})
+check (negative_argument, {'-f', '-2'}, {val=-2, flag=true})
+check (negative_argument, {'--flag', '-2'}, {val=-2, flag=true})
+check (negative_argument, {'-29.2'}, {val=-29.2, flag=false})
+check (negative_argument, {'202.2'}, {val=202.2, flag=false})
+
+
 local addtype = [[
   -l (intlist) List of items
 ]]
@@ -199,4 +212,5 @@ test.asserteq(lapp(spec,{'-vs',200,'-sk',1}),{
   dbg = false,
   width = 256
 })
+
 

--- a/tests/test-lapp.lua
+++ b/tests/test-lapp.lua
@@ -213,4 +213,3 @@ test.asserteq(lapp(spec,{'-vs',200,'-sk',1}),{
   width = 256
 })
 
-


### PR DESCRIPTION
I've noticed that lapp doesn't allow negative numbers because they are treated as flags.