### PR TITLE
enable lapp to have advanced characters in enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    [#405](https://github.com/lunarmodules/Penlight/pull/405)
  - feat: `array2d.default_range` now also takes a spreadsheet range, which means
    also other functions now take a range. [#404](https://github.com/lunarmodules/Penlight/pull/404)
+ - fix: `lapp` enums allow [patterns magic characters](https://www.lua.org/pil/20.2.html)
+   [#393](https://github.com/lunarmodules/Penlight/pull/393)
 
 ## 1.11.0 (2021-08-18)
 

--- a/lua/pl/lapp.lua
+++ b/lua/pl/lapp.lua
@@ -277,7 +277,7 @@ function lapp.process_options_string(str,args)
                         local enump = '|' .. enums .. '|'
                         vtype = 'string'
                         constraint = function(s)
-                            lapp.assert(enump:match('|'..s..'|'),
+                            lapp.assert(enump:find('|'..s..'|', 1, true),
                               "value '"..s.."' not in "..enums
                             )
                         end

--- a/tests/test-lapp.lua
+++ b/tests/test-lapp.lua
@@ -118,6 +118,15 @@ check_error(extended,{'-n','x'},"unable to convert to number: x")
 
 check_error(extended,{'-n','12'},"n out of range")
 
+local with_advanced_enum = [[
+  -s  (test1|test2()|%a)
+  -c  (1-2|2-3|cool[])
+]]
+
+check(with_advanced_enum,{"-s", "test2()", "-c", "1-2"},{s='test2()',c='1-2'})
+check(with_advanced_enum,{"-s", "test2()", "-c", "2-3"},{s='test2()',c='2-3'})
+check(with_advanced_enum,{"-s", "%a", "-c", "2-3"},{s='%a',c='2-3'})
+
 local with_dashes = [[
   --first-dash  dash
   --second-dash dash also


### PR DESCRIPTION
Currently lapp fails to parse enums that have advanced characters `-()` due to `string.match` treating them as pattern matching elements. Switch to using `string.find` with `plain=true`