### PR TITLE
Fixes import_into using the previous environment's __newindex if set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    [#400](https://github.com/lunarmodules/Penlight/pull/400)
  - fix: `stringx.expandtabs` could error out on Lua 5.3+
    [#406](https://github.com/lunarmodules/Penlight/pull/406)
+ - fix: `pl` the module would not properly forward the `newindex` metamethod
+   on the global table.
+   [#395](https://github.com/lunarmodules/Penlight/pull/395)
 
 ## 1.11.0 (2021-08-18)
 

--- a/lua/pl/import_into.lua
+++ b/lua/pl/import_into.lua
@@ -50,7 +50,7 @@ return function(env)
     if prevenvmt then
         _prev_index = prevenvmt.__index
         if prevenvmt.__newindex then
-            gmt.__index = prevenvmt.__newindex
+            gmt.__newindex = prevenvmt.__newindex
         end
     end
 


### PR DESCRIPTION
This seems like a typo; gmt.__index is always overridden below, so this currently would do nothing, and we wouldn't want to use another table's __newindex as this table's __index.

gmt does sometimes have its own __newindex set below, but AFAICT the case where it's set is mutually exclusive with this case. (__newindex is only set if mod is truthy; mod is truthy if env is originally true, in which case it is set to an empty table; prevenvmt is env's metatable, so not set in that case.)