### PR TITLE
[fix] text.wrap now returns non-empty list for one character strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    [#396](https://github.com/lunarmodules/Penlight/pull/396)
  - fix: `text.dedent` didn't handle declining indents nor empty lines
    [#402](https://github.com/lunarmodules/Penlight/pull/402)
+<<<<<<< HEAD
  - fix: `dir.getfiles`, `dir.getdirectories`, and `dir.getallfiles` now have the
    directory optional, as was already documented
    [#405](https://github.com/lunarmodules/Penlight/pull/405)
@@ -20,6 +21,14 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    also other functions now take a range. [#404](https://github.com/lunarmodules/Penlight/pull/404)
  - fix: `lapp` enums allow [patterns magic characters](https://www.lua.org/pil/20.2.html)
    [#393](https://github.com/lunarmodules/Penlight/pull/393)
+=======
+ - fix: `text.wrap` and `text.fill` numerous fixes for handling whitespace,
+   accented characters, honouring width, etc.
+   [#400](https://github.com/lunarmodules/Penlight/pull/400)
+ - feat: `text.wrap` and `text.fill` have a new parameter to forcefully break words
+   longer than the width given.
+   [#400](https://github.com/lunarmodules/Penlight/pull/400)
+>>>>>>> 7b3efef4 (feat(text) wrap/fill can break long words, honours width)
 
 ## 1.11.0 (2021-08-18)
 

--- a/lua/pl/text.lua
+++ b/lua/pl/text.lua
@@ -102,15 +102,15 @@ function text.wrap (s,width)
     s = s:gsub('\n',' ')
     local i,nxt = 1
     local lines,line = {}
-    while i < #s do
+    repeat
         nxt = i+width
-        if s:find("[%w']",nxt) then -- inside a word
-            nxt = s:find('%W',nxt+1) -- so find word boundary
+        if s:find("%S",nxt) then -- inside a word
+            nxt = s:find('%s',nxt) -- so find word boundary
         end
         line = s:sub(i,nxt)
         i = i + #line
         append(lines,strip(line))
-    end
+    until i > (#s - 1)
     return makelist(lines)
 end
 

--- a/spec/text_spec.lua
+++ b/spec/text_spec.lua
@@ -165,34 +165,6 @@ three
 
   describe("fill()/wrap()", function()
 
-    it("word-wraps a text", function()
-      assert.equal([[
-It is often said of Lua
-that it does not include
-batteries. That is because
-the goal of Lua is to
-produce a lean expressive
-language that will be
-used on all sorts of
-machines, (some of which
-don't even have hierarchical
-filesystems). The Lua
-language is the equivalent
-of an operating system
-kernel; the creators
-of Lua do not see it
-as their responsibility
-to create a full software
-ecosystem around the
-language. That is the
-role of the community.
-]], text.fill("It is often said of Lua that it does not include batteries. That is because the goal of Lua is to produce a lean expressive language that will be used on all sorts of machines, (some of which don't even have hierarchical filesystems). The Lua language is the equivalent of an operating system kernel; the creators of Lua do not see it as their responsibility to create a full software ecosystem around the language. That is the role of the community.", 20))
-    end)
-
-    it("wraps single letters", function()
-      assert.same({"a"}, text.wrap("a"))
-    end)
-
     it("wraps width over limit", function()
       assert.same({
         "abc",
@@ -205,15 +177,72 @@ role of the community.
         "abc",
         "def"
       }, text.wrap("abc def", 3))
+      assert.same({
+        "a c",
+        "d f"
+      }, text.wrap("a c d f", 3))
+    end)
+
+    it("wraps single letters", function()
+      assert.same({"a"}, text.wrap("a"))
+    end)
+
+    it("wraps empty strings", function()
+      assert.same({""}, text.wrap(""))
+      assert.same({""}, text.wrap("    "))
+    end)
+
+    it("handles leading/trailing whitespace", function()
+      assert.same({"hello"}, text.wrap("     hello     ", 10))
+      assert.same({"hello"}, text.wrap("     hello     ", 2))
+      assert.same({"he", "ll", "o"}, text.wrap("     hello     ", 2, true))
+    end)
+
+    it("handles line-breaks", function()
+      assert.same({"Hello", "Dolly"}, text.wrap("Hello\nDolly", 10))
+      assert.same({"Hello Dolly"}, text.wrap("Hello\nDolly", 20))
     end)
 
     it("doesn't split on accented characters", function()
       assert.same({"àbcdéfghîj"}, text.wrap("àbcdéfghîj"))
     end)
 
+    it("word-wraps a text", function()
+      local binstring = require("luassert.formatters.binarystring")
+      assert:add_formatter(binstring)
+      assert.equal([[
+It is often said of
+Lua that it does not
+include batteries.
+That is because the
+goal of Lua is to
+produce a lean
+expressive language
+that will be used on
+all sorts of
+machines, (some of
+which don't even
+have hierarchical
+filesystems). The
+Lua language is the
+equivalent of an
+operating system
+kernel; the creators
+of Lua do not see it
+as their
+responsibility to
+create a full
+software ecosystem
+around the language.
+That is the role of
+the community.
+]], text.fill("It is often said of Lua that it does not include batteries. That is because the goal of Lua is to produce a lean expressive language that will be used on all sorts of machines, (some of which don't even have hierarchical filesystems). The Lua language is the equivalent of an operating system kernel; the creators of Lua do not see it as their responsibility to create a full software ecosystem around the language. That is the role of the community.", 20))
+    end)
+
+
     it("generic wrap test", function()
       local t = [[
-hello "world" 'this' -is- a bb ccc dddd test... but wouldn't it pass??? final. word-that-can-be-broken
+hello "world" 'this' -is- a bb      ccc dddd test... but wouldn't it pass??? final. word-that-can-be-broken
 ]]
 
       assert.same({
@@ -221,16 +250,61 @@ hello "world" 'this' -is- a bb ccc dddd test... but wouldn't it pass??? final. w
         '"world"',
         "'this'",
         "-is-",
-        "a bb",
+        "a",
+        "bb",
         "ccc",
         "dddd",
         "test...",
         "but",
         "wouldn't",
-        "it pass???",
+        "it",
+        "pass???",
         "final.",
         "word-that-can-be-broken",
       }, text.wrap(t, 3))
+    end)
+
+    it("generic wrap test, with overflow breaking", function()
+      local t = [[
+hello "world" 'this' -is- a bb      ccc dddd test... but wouldn't it pass??? final. word-that-can-be-broken
+]]
+
+      assert.same({
+        "hel",
+        "lo",
+        '"wo',
+        'rld',
+        '"',
+        "'th",
+        "is'",
+        "-is",
+        "- a",
+        "bb",
+        "ccc",
+        "ddd",
+        "d",
+        "tes",
+        "t..",
+        ".",
+        "but",
+        "wou",
+        "ldn",
+        "'t",
+        "it",
+        "pas",
+        "s??",
+        "?",
+        "fin",
+        "al.",
+        "wor",
+        "d-t",
+        "hat",
+        "-ca",
+        "n-b",
+        "e-b",
+        "rok",
+        "en",
+      }, text.wrap(t, 3, true))
     end)
 
   end)

--- a/spec/text_spec.lua
+++ b/spec/text_spec.lua
@@ -161,5 +161,79 @@ three
 
   end)
 
+
+
+  describe("fill()/wrap()", function()
+
+    it("word-wraps a text", function()
+      assert.equal([[
+It is often said of Lua
+that it does not include
+batteries. That is because
+the goal of Lua is to
+produce a lean expressive
+language that will be
+used on all sorts of
+machines, (some of which
+don't even have hierarchical
+filesystems). The Lua
+language is the equivalent
+of an operating system
+kernel; the creators
+of Lua do not see it
+as their responsibility
+to create a full software
+ecosystem around the
+language. That is the
+role of the community.
+]], text.fill("It is often said of Lua that it does not include batteries. That is because the goal of Lua is to produce a lean expressive language that will be used on all sorts of machines, (some of which don't even have hierarchical filesystems). The Lua language is the equivalent of an operating system kernel; the creators of Lua do not see it as their responsibility to create a full software ecosystem around the language. That is the role of the community.", 20))
+    end)
+
+    it("wraps single letters", function()
+      assert.same({"a"}, text.wrap("a"))
+    end)
+
+    it("wraps width over limit", function()
+      assert.same({
+        "abc",
+        "def"
+      }, text.wrap("abc def", 2))
+    end)
+
+    it("wraps width at limit", function()
+      assert.same({
+        "abc",
+        "def"
+      }, text.wrap("abc def", 3))
+    end)
+
+    it("doesn't split on accented characters", function()
+      assert.same({"àbcdéfghîj"}, text.wrap("àbcdéfghîj"))
+    end)
+
+    it("generic wrap test", function()
+      local t = [[
+hello "world" 'this' -is- a bb ccc dddd test... but wouldn't it pass??? final. word-that-can-be-broken
+]]
+
+      assert.same({
+        "hello",
+        '"world"',
+        "'this'",
+        "-is-",
+        "a bb",
+        "ccc",
+        "dddd",
+        "test...",
+        "but",
+        "wouldn't",
+        "it pass???",
+        "final.",
+        "word-that-can-be-broken",
+      }, text.wrap(t, 3))
+    end)
+
+  end)
+
 end)
 


### PR DESCRIPTION
`text.wrap` returns empty list for one-character strings, this PR fixes this by using `<=` instead of `<` for the iterator