### PR TITLE
update utils; enum + kpairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,13 @@ deprecation policy.
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
 ## 1.13.0 (unreleased)
-<<<<<<< HEAD
  - fix: `compat.warn` raised write guard warning in OpenResty
    [#414](https://github.com/lunarmodules/Penlight/pull/414)
-=======
  - feat: `utils.enum` now accepts hash tables, to enable better error handling
    [#413](https://github.com/lunarmodules/Penlight/pull/413)
  - feat: `utils.kpairs` new iterator over all non-integer keys
    [#413](https://github.com/lunarmodules/Penlight/pull/413)
 
->>>>>>> b38c390 (feat(utils) enum to accept hash tables as well)
 
 ## 1.12.0 (2022-Jan-10)
  - deprecate: module `pl.text` the contents have moved to `pl.stringx` (removal later)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    [#414](https://github.com/lunarmodules/Penlight/pull/414)
 =======
  - feat: `utils.enum` now accepts hash tables, to enable better error handling
+   [#413](https://github.com/lunarmodules/Penlight/pull/413)
+ - feat: `utils.kpairs` new iterator over all non-integer keys
+   [#413](https://github.com/lunarmodules/Penlight/pull/413)
 
 >>>>>>> b38c390 (feat(utils) enum to accept hash tables as well)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ deprecation policy.
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
 ## 1.13.0 (unreleased)
+<<<<<<< HEAD
  - fix: `compat.warn` raised write guard warning in OpenResty
    [#414](https://github.com/lunarmodules/Penlight/pull/414)
+=======
+ - feat: `utils.enum` now accepts hash tables, to enable better error handling
+
+>>>>>>> b38c390 (feat(utils) enum to accept hash tables as well)
 
 ## 1.12.0 (2022-Jan-10)
  - deprecate: module `pl.text` the contents have moved to `pl.stringx` (removal later)

--- a/lua/pl/utils.lua
+++ b/lua/pl/utils.lua
@@ -13,6 +13,8 @@ local concat = table.concat
 local _unpack = table.unpack  -- always injected by 'compat'
 local find = string.find
 local sub = string.sub
+local next = next
+local floor = math.floor
 
 local is_windows = compat.is_windows
 local err_mode = 'default'
@@ -218,6 +220,47 @@ function utils.npairs(t, i_start, i_end, step)
       end
       return i, t[i]
     end
+  end
+end
+
+
+
+--- an iterator over all non-integer keys (inverse of `ipairs`).
+-- It will skip any key that is an integer number, so negative indices or an
+-- array with holes will not return those either (so it returns slightly less than
+-- 'the inverse of `ipairs`').
+--
+-- This uses `pairs` under the hood, so any value that is iterable using `pairs`
+-- will work with this function.
+-- @tparam table t the table to iterate over
+-- @treturn key
+-- @treturn value
+-- @usage
+-- local t = {
+--   "hello",
+--   "world",
+--   hello = "hallo",
+--   world = "Welt",
+-- }
+--
+-- for k, v in utils.kpairs(t) do
+--   print("German: ", v)
+-- end
+--
+-- -- output;
+-- -- German: hallo
+-- -- German: Welt
+function utils.kpairs(t)
+  local index
+  return function()
+    local value
+    while true do
+      index, value = next(t, index)
+      if type(index) ~= "number" or floor(index) ~= index then
+        break
+      end
+    end
+    return index, value
   end
 end
 

--- a/lua/pl/utils.lua
+++ b/lua/pl/utils.lua
@@ -360,7 +360,7 @@ function utils.enum(...)
   if type(first) ~= "table" then
     -- vararg with strings
     lst = utils.pack(...)
-    for i, value in ipairs(lst) do
+    for i, value in utils.npairs(lst) do
       utils.assert_arg(i, value, "string")
       enum[value] = value
     end
@@ -378,17 +378,15 @@ function utils.enum(...)
       enum[value] = value
     end
     -- add key-ed part
-    for key, value in pairs(first) do
-      if not lst[key] then
-        if type(key) ~= "string" then
-          error(("expected key to be 'string' but got '%s'"):format(type(key)), 2)
-        end
-          if enum[key] then
-          error(("duplicate entry in array and hash part: '%s'"):format(key), 2)
-        end
-        enum[key] = value
-        lst[#lst+1] = key
+    for key, value in utils.kpairs(first) do
+      if type(key) ~= "string" then
+        error(("expected key to be 'string' but got '%s'"):format(type(key)), 2)
       end
+      if enum[key] then
+        error(("duplicate entry in array and hash part: '%s'"):format(key), 2)
+      end
+      enum[key] = value
+      lst[#lst+1] = key
     end
   end
 

--- a/spec/utils-enum_spec.lua
+++ b/spec/utils-enum_spec.lua
@@ -24,6 +24,10 @@ describe("pl.utils", function ()
         assert.has.error(function()
           t = enum("hello", true, "world")
         end, "argument 2 expected a 'string', got a 'boolean'")
+        -- no holes
+        assert.has.error(function()
+          t = enum("hello", nil, "world")
+        end, "argument 2 expected a 'string', got a 'nil'")
       end)
 
 

--- a/spec/utils-enum_spec.lua
+++ b/spec/utils-enum_spec.lua
@@ -5,19 +5,118 @@ describe("pl.utils", function ()
 
     before_each(function()
       enum = require("pl.utils").enum
-      t = enum("ONE", "two", "THREE")
     end)
 
 
-    it("holds enumerated values", function()
-      assert.equal("ONE", t.ONE)
-      assert.equal("two", t.two)
-      assert.equal("THREE", t.THREE)
+    describe("creating", function()
+
+      it("accepts a vararg", function()
+        t = enum("ONE", "two", "THREE")
+        assert.same({
+          ONE = "ONE",
+          two = "two",
+          THREE = "THREE",
+        }, t)
+      end)
+
+
+      it("vararg entries must be strings", function()
+        assert.has.error(function()
+          t = enum("hello", true, "world")
+        end, "argument 2 expected a 'string', got a 'boolean'")
+      end)
+
+
+      it("vararg requires at least 1 entry", function()
+        assert.has.error(function()
+          t = enum()
+        end, "expected at least 1 entry")
+      end)
+
+
+      it("accepts an array", function()
+        t = enum { "ONE", "two", "THREE" }
+        assert.same({
+          ONE = "ONE",
+          two = "two",
+          THREE = "THREE",
+        }, t)
+      end)
+
+
+      it("array entries must be strings", function()
+        assert.has.error(function()
+          t = enum { "ONE", 999, "THREE" }
+        end, "expected 'string' but got 'number' at index 2")
+      end)
+
+
+      it("array requires at least 1 entry", function()
+        assert.has.error(function()
+          t = enum {}
+        end, "expected at least 1 entry")
+      end)
+
+
+      it("accepts a hash-table", function()
+        t = enum {
+          FILE_NOT_FOUND = "The file was not found in the filesystem",
+          FILE_READ_ONLY = "The file is read-only",
+        }
+        assert.same({
+          FILE_NOT_FOUND = "The file was not found in the filesystem",
+          FILE_READ_ONLY = "The file is read-only",
+        }, t)
+      end)
+
+
+      it("hash-table keys must be strings", function()
+        assert.has.error(function()
+          t = enum { [{}] = "ONE" }
+        end, "expected key to be 'string' but got 'table'")
+      end)
+
+
+      it("hash-table requires at least 1 entry", function()
+        assert.has.error(function()
+          t = enum {}
+        end, "expected at least 1 entry")
+      end)
+
+
+      it("accepts a combined array/hash-table", function()
+        t = enum {
+          "BAD_FD",
+          FILE_NOT_FOUND = "The file was not found in the filesystem",
+          FILE_READ_ONLY = "The file is read-only",
+        }
+        assert.same({
+          BAD_FD = "BAD_FD",
+          FILE_NOT_FOUND = "The file was not found in the filesystem",
+          FILE_READ_ONLY = "The file is read-only",
+        }, t)
+      end)
+
+
+      it("keys must be unique with combined array/has-table", function()
+        assert.has.error(function()
+          t = enum {
+            "FILE_NOT_FOUND",
+            FILE_NOT_FOUND = "The file was not found in the filesystem",
+          }
+          end, "duplicate entry in array and hash part: 'FILE_NOT_FOUND'")
+      end)
+
     end)
 
 
 
     describe("accessing", function()
+
+      before_each(function()
+        t = enum("ONE", "two", "THREE")
+      end)
+
 
       it("errors on unknown values", function()
         assert.has.error(function()
@@ -33,20 +132,6 @@ describe("pl.utils", function ()
       end)
 
 
-      it("entries must be strings", function()
-        assert.has.error(function()
-          t = enum("hello", true, "world")
-        end, "argument 2 expected a 'string', got a 'boolean'")
-      end)
-
-
-      it("requires at least 1 entry", function()
-        assert.has.error(function()
-          t = enum()
-        end, "argument 1 expected a 'string', got a 'nil'")
-      end)
-
-
       it("keys can have 'format' placeholders", function()
         t = enum("hello", "contains: %s")
         assert.has.error(function()
@@ -59,6 +144,11 @@ describe("pl.utils", function ()
 
 
     describe("calling", function()
+
+      before_each(function()
+        t = enum("ONE", "two", "THREE")
+      end)
+
 
       it("returns error on unknown values", function()
         local ok, err = t("four")

--- a/spec/utils-kpairs_spec.lua
+++ b/spec/utils-kpairs_spec.lua
@@ -1,0 +1,38 @@
+local utils = require("pl.utils")
+
+describe("pl.utils", function ()
+
+  describe("kpairs", function ()
+    local kpairs
+
+    before_each(function()
+      kpairs = utils.kpairs
+    end)
+
+
+    it("iterates over non-integers", function()
+      local func = function() end
+      local bool = true
+      local string = "a string"
+      local float = 123.45
+      local r = {}
+      for k, v in kpairs {
+        [func] = 1,
+        [bool] = 2,
+        [string] = 3,
+        [float] = 4,
+        5, 6, 7,
+      } do
+        r[k] = v
+      end
+
+      assert.same({
+        [func] = 1,
+        [bool] = 2,
+        [string] = 3,
+        [float] = 4 }, r)
+    end)
+
+  end)
+
+end)


### PR DESCRIPTION
adds:

- feature: `utils.enum` accept hash tables as well
- feature: `utils.kpairs` iterator over all non-integer keys (inverse of ipairs)