### PR TITLE
Make compat.warn compatible with OpenResty's global scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ deprecation policy.
 
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
+## 1.13.0 (unreleased)
+ - fix: `compat.warn` raised write guard warning in OpenResty
+   [#414](https://github.com/lunarmodules/Penlight/pull/414)
+
 ## 1.12.0 (2022-Jan-10)
  - deprecate: module `pl.text` the contents have moved to `pl.stringx` (removal later)
    [#407](https://github.com/lunarmodules/Penlight/pull/407)

--- a/lua/pl/compat.lua
+++ b/lua/pl/compat.lua
@@ -227,7 +227,7 @@ end
 -- @param ... any arguments
 if not warn then  -- luacheck: ignore
     local enabled = false
-    function warn(arg1, ...)  -- luacheck: ignore
+    local function warn(arg1, ...)  -- luacheck: ignore
         if type(arg1) == "string" and arg1:sub(1, 1) == "@" then
             -- control message
             if arg1 == "@on" then
@@ -245,6 +245,8 @@ if not warn then  -- luacheck: ignore
           io.stderr:write("\n")
         end
     end
+    -- use rawset to bypass OpenResty's protection of global scope
+    rawset(_G, "warn", warn)
 end
 
 return compat


### PR DESCRIPTION
Fixes #412