### PR TITLE
Update all rockspecs so they can actually still pull from GitHub

### DIFF
--- a/penlight-dev-1.rockspec
+++ b/penlight-dev-1.rockspec
@@ -11,7 +11,7 @@ package = package_name
 version = package_version .. "-" .. rockspec_revision
 
 source = {
-  url = "git://github.com/"..github_account_name.."/"..github_repo_name..".git",
+  url = "git+https://github.com/"..github_account_name.."/"..github_repo_name..".git",
   branch = git_checkout
 }
 

--- a/rockspecs/penlight-1.10.0-2.rockspec
+++ b/rockspecs/penlight-1.10.0-2.rockspec
@@ -1,0 +1,78 @@
+local package_name = "penlight"
+local package_version = "1.10.0"
+local rockspec_revision = "2"
+local github_account_name = "lunarmodules"
+local github_repo_name = package_name
+local git_checkout = package_version == "dev" and "master" or package_version
+
+
+package = package_name
+version = package_version .. "-" .. rockspec_revision
+
+source = {
+  url = "git+https://github.com/"..github_account_name.."/"..github_repo_name..".git",
+  branch = git_checkout
+}
+
+description = {
+  summary = "Lua utility libraries loosely based on the Python standard libraries",
+  homepage = "https://"..github_account_name..".github.io/"..github_repo_name,
+  license = "MIT/X11",
+  maintainer = "thijs@thijsschreijer.nl",
+  detailed = [[
+Penlight is a set of pure Lua libraries for making it easier to work with common tasks like
+iterating over directories, reading configuration files and the like. Provides functional operations
+on tables and sequences.
+]]
+}
+
+dependencies = {
+  "luafilesystem",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["pl.strict"] = "lua/pl/strict.lua",
+    ["pl.dir"] = "lua/pl/dir.lua",
+    ["pl.operator"] = "lua/pl/operator.lua",
+    ["pl.input"] = "lua/pl/input.lua",
+    ["pl.config"] = "lua/pl/config.lua",
+    ["pl.compat"] = "lua/pl/config.lua",
+    ["pl.seq"] = "lua/pl/seq.lua",
+    ["pl.stringio"] = "lua/pl/stringio.lua",
+    ["pl.text"] = "lua/pl/text.lua",
+    ["pl.test"] = "lua/pl/test.lua",
+    ["pl.tablex"] = "lua/pl/tablex.lua",
+    ["pl.app"] = "lua/pl/app.lua",
+    ["pl.stringx"] = "lua/pl/stringx.lua",
+    ["pl.lexer"] = "lua/pl/lexer.lua",
+    ["pl.utils"] = "lua/pl/utils.lua",
+    ["pl.sip"] = "lua/pl/sip.lua",
+    ["pl.permute"] = "lua/pl/permute.lua",
+    ["pl.pretty"] = "lua/pl/pretty.lua",
+    ["pl.class"] = "lua/pl/class.lua",
+    ["pl.List"] = "lua/pl/List.lua",
+    ["pl.data"] = "lua/pl/data.lua",
+    ["pl.Date"] = "lua/pl/Date.lua",
+    ["pl.init"] = "lua/pl/init.lua",
+    ["pl.luabalanced"] = "lua/pl/luabalanced.lua",
+    ["pl.comprehension"] = "lua/pl/comprehension.lua",
+    ["pl.path"] = "lua/pl/path.lua",
+    ["pl.array2d"] = "lua/pl/array2d.lua",
+    ["pl.func"] = "lua/pl/func.lua",
+    ["pl.lapp"] = "lua/pl/lapp.lua",
+    ["pl.file"] = "lua/pl/file.lua",
+    ['pl.template'] = "lua/pl/template.lua",
+    ["pl.Map"] = "lua/pl/Map.lua",
+    ["pl.MultiMap"] = "lua/pl/MultiMap.lua",
+    ["pl.OrderedMap"] = "lua/pl/OrderedMap.lua",
+    ["pl.Set"] = "lua/pl/Set.lua",
+    ["pl.xml"] = "lua/pl/xml.lua",
+    ["pl.url"] = "lua/pl/url.lua",
+    ["pl.import_into"] = "lua/pl/import_into.lua",
+    ["pl.types"] = "lua/pl/types.lua",
+  },
+  copy_directories = {"docs", "tests"}
+}
+

--- a/rockspecs/penlight-1.11.0-2.rockspec
+++ b/rockspecs/penlight-1.11.0-2.rockspec
@@ -1,0 +1,78 @@
+local package_name = "penlight"
+local package_version = "1.11.0"
+local rockspec_revision = "2"
+local github_account_name = "lunarmodules"
+local github_repo_name = package_name
+local git_checkout = package_version == "dev" and "master" or package_version
+
+
+package = package_name
+version = package_version .. "-" .. rockspec_revision
+
+source = {
+  url = "git+https://github.com/"..github_account_name.."/"..github_repo_name..".git",
+  branch = git_checkout
+}
+
+description = {
+  summary = "Lua utility libraries loosely based on the Python standard libraries",
+  homepage = "https://"..github_account_name..".github.io/"..github_repo_name,
+  license = "MIT/X11",
+  maintainer = "thijs@thijsschreijer.nl",
+  detailed = [[
+Penlight is a set of pure Lua libraries for making it easier to work with common tasks like
+iterating over directories, reading configuration files and the like. Provides functional operations
+on tables and sequences.
+]]
+}
+
+dependencies = {
+  "luafilesystem",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["pl.strict"] = "lua/pl/strict.lua",
+    ["pl.dir"] = "lua/pl/dir.lua",
+    ["pl.operator"] = "lua/pl/operator.lua",
+    ["pl.input"] = "lua/pl/input.lua",
+    ["pl.config"] = "lua/pl/config.lua",
+    ["pl.compat"] = "lua/pl/config.lua",
+    ["pl.seq"] = "lua/pl/seq.lua",
+    ["pl.stringio"] = "lua/pl/stringio.lua",
+    ["pl.text"] = "lua/pl/text.lua",
+    ["pl.test"] = "lua/pl/test.lua",
+    ["pl.tablex"] = "lua/pl/tablex.lua",
+    ["pl.app"] = "lua/pl/app.lua",
+    ["pl.stringx"] = "lua/pl/stringx.lua",
+    ["pl.lexer"] = "lua/pl/lexer.lua",
+    ["pl.utils"] = "lua/pl/utils.lua",
+    ["pl.sip"] = "lua/pl/sip.lua",
+    ["pl.permute"] = "lua/pl/permute.lua",
+    ["pl.pretty"] = "lua/pl/pretty.lua",
+    ["pl.class"] = "lua/pl/class.lua",
+    ["pl.List"] = "lua/pl/List.lua",
+    ["pl.data"] = "lua/pl/data.lua",
+    ["pl.Date"] = "lua/pl/Date.lua",
+    ["pl.init"] = "lua/pl/init.lua",
+    ["pl.luabalanced"] = "lua/pl/luabalanced.lua",
+    ["pl.comprehension"] = "lua/pl/comprehension.lua",
+    ["pl.path"] = "lua/pl/path.lua",
+    ["pl.array2d"] = "lua/pl/array2d.lua",
+    ["pl.func"] = "lua/pl/func.lua",
+    ["pl.lapp"] = "lua/pl/lapp.lua",
+    ["pl.file"] = "lua/pl/file.lua",
+    ['pl.template'] = "lua/pl/template.lua",
+    ["pl.Map"] = "lua/pl/Map.lua",
+    ["pl.MultiMap"] = "lua/pl/MultiMap.lua",
+    ["pl.OrderedMap"] = "lua/pl/OrderedMap.lua",
+    ["pl.Set"] = "lua/pl/Set.lua",
+    ["pl.xml"] = "lua/pl/xml.lua",
+    ["pl.url"] = "lua/pl/url.lua",
+    ["pl.import_into"] = "lua/pl/import_into.lua",
+    ["pl.types"] = "lua/pl/types.lua",
+  },
+  copy_directories = {"docs", "tests"}
+}
+

--- a/rockspecs/penlight-1.12.0-2.rockspec
+++ b/rockspecs/penlight-1.12.0-2.rockspec
@@ -1,0 +1,78 @@
+local package_name = "penlight"
+local package_version = "1.12.0"
+local rockspec_revision = "2"
+local github_account_name = "lunarmodules"
+local github_repo_name = package_name
+local git_checkout = package_version == "dev" and "master" or package_version
+
+
+package = package_name
+version = package_version .. "-" .. rockspec_revision
+
+source = {
+  url = "git+https://github.com/"..github_account_name.."/"..github_repo_name..".git",
+  branch = git_checkout
+}
+
+description = {
+  summary = "Lua utility libraries loosely based on the Python standard libraries",
+  homepage = "https://"..github_account_name..".github.io/"..github_repo_name,
+  license = "MIT/X11",
+  maintainer = "thijs@thijsschreijer.nl",
+  detailed = [[
+Penlight is a set of pure Lua libraries for making it easier to work with common tasks like
+iterating over directories, reading configuration files and the like. Provides functional operations
+on tables and sequences.
+]]
+}
+
+dependencies = {
+  "luafilesystem",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["pl.strict"] = "lua/pl/strict.lua",
+    ["pl.dir"] = "lua/pl/dir.lua",
+    ["pl.operator"] = "lua/pl/operator.lua",
+    ["pl.input"] = "lua/pl/input.lua",
+    ["pl.config"] = "lua/pl/config.lua",
+    ["pl.compat"] = "lua/pl/config.lua",
+    ["pl.seq"] = "lua/pl/seq.lua",
+    ["pl.stringio"] = "lua/pl/stringio.lua",
+    ["pl.text"] = "lua/pl/text.lua",
+    ["pl.test"] = "lua/pl/test.lua",
+    ["pl.tablex"] = "lua/pl/tablex.lua",
+    ["pl.app"] = "lua/pl/app.lua",
+    ["pl.stringx"] = "lua/pl/stringx.lua",
+    ["pl.lexer"] = "lua/pl/lexer.lua",
+    ["pl.utils"] = "lua/pl/utils.lua",
+    ["pl.sip"] = "lua/pl/sip.lua",
+    ["pl.permute"] = "lua/pl/permute.lua",
+    ["pl.pretty"] = "lua/pl/pretty.lua",
+    ["pl.class"] = "lua/pl/class.lua",
+    ["pl.List"] = "lua/pl/List.lua",
+    ["pl.data"] = "lua/pl/data.lua",
+    ["pl.Date"] = "lua/pl/Date.lua",
+    ["pl.init"] = "lua/pl/init.lua",
+    ["pl.luabalanced"] = "lua/pl/luabalanced.lua",
+    ["pl.comprehension"] = "lua/pl/comprehension.lua",
+    ["pl.path"] = "lua/pl/path.lua",
+    ["pl.array2d"] = "lua/pl/array2d.lua",
+    ["pl.func"] = "lua/pl/func.lua",
+    ["pl.lapp"] = "lua/pl/lapp.lua",
+    ["pl.file"] = "lua/pl/file.lua",
+    ['pl.template'] = "lua/pl/template.lua",
+    ["pl.Map"] = "lua/pl/Map.lua",
+    ["pl.MultiMap"] = "lua/pl/MultiMap.lua",
+    ["pl.OrderedMap"] = "lua/pl/OrderedMap.lua",
+    ["pl.Set"] = "lua/pl/Set.lua",
+    ["pl.xml"] = "lua/pl/xml.lua",
+    ["pl.url"] = "lua/pl/url.lua",
+    ["pl.import_into"] = "lua/pl/import_into.lua",
+    ["pl.types"] = "lua/pl/types.lua",
+  },
+  copy_directories = {"docs", "tests"}
+}
+

--- a/rockspecs/penlight-1.6.0-2.rockspec
+++ b/rockspecs/penlight-1.6.0-2.rockspec
@@ -1,0 +1,70 @@
+package = "penlight"
+version = "1.6.0-2"
+
+source = {
+  url = "git+https://github.com/Tieske/Penlight.git",
+  branch = "1.6.0"
+}
+
+description = {
+  summary = "Lua utility libraries loosely based on the Python standard libraries",
+  homepage = "http://tieske.github.io/Penlight",
+  license = "MIT/X11",
+  maintainer = "thijs@thijsschreijer.nl",
+  detailed = [[
+Penlight is a set of pure Lua libraries for making it easier to work with common tasks like
+iterating over directories, reading configuration files and the like. Provides functional operations
+on tables and sequences.
+]]
+}
+
+dependencies = {
+  "luafilesystem",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["pl.strict"] = "lua/pl/strict.lua",
+    ["pl.dir"] = "lua/pl/dir.lua",
+    ["pl.operator"] = "lua/pl/operator.lua",
+    ["pl.input"] = "lua/pl/input.lua",
+    ["pl.config"] = "lua/pl/config.lua",
+    ["pl.compat"] = "lua/pl/config.lua",
+    ["pl.seq"] = "lua/pl/seq.lua",
+    ["pl.stringio"] = "lua/pl/stringio.lua",
+    ["pl.text"] = "lua/pl/text.lua",
+    ["pl.test"] = "lua/pl/test.lua",
+    ["pl.tablex"] = "lua/pl/tablex.lua",
+    ["pl.app"] = "lua/pl/app.lua",
+    ["pl.stringx"] = "lua/pl/stringx.lua",
+    ["pl.lexer"] = "lua/pl/lexer.lua",
+    ["pl.utils"] = "lua/pl/utils.lua",
+    ["pl.sip"] = "lua/pl/sip.lua",
+    ["pl.permute"] = "lua/pl/permute.lua",
+    ["pl.pretty"] = "lua/pl/pretty.lua",
+    ["pl.class"] = "lua/pl/class.lua",
+    ["pl.List"] = "lua/pl/List.lua",
+    ["pl.data"] = "lua/pl/data.lua",
+    ["pl.Date"] = "lua/pl/Date.lua",
+    ["pl.init"] = "lua/pl/init.lua",
+    ["pl.luabalanced"] = "lua/pl/luabalanced.lua",
+    ["pl.comprehension"] = "lua/pl/comprehension.lua",
+    ["pl.path"] = "lua/pl/path.lua",
+    ["pl.array2d"] = "lua/pl/array2d.lua",
+    ["pl.func"] = "lua/pl/func.lua",
+    ["pl.lapp"] = "lua/pl/lapp.lua",
+    ["pl.file"] = "lua/pl/file.lua",
+    ['pl.template'] = "lua/pl/template.lua",
+    ["pl.Map"] = "lua/pl/Map.lua",
+    ["pl.MultiMap"] = "lua/pl/MultiMap.lua",
+    ["pl.OrderedMap"] = "lua/pl/OrderedMap.lua",
+    ["pl.Set"] = "lua/pl/Set.lua",
+    ["pl.xml"] = "lua/pl/xml.lua",
+    ["pl.url"] = "lua/pl/url.lua",
+    ["pl.import_into"] = "lua/pl/import_into.lua",
+    ["pl.types"] = "lua/pl/types.lua",
+  },
+  copy_directories = {"docs", "tests"}
+}
+

--- a/rockspecs/penlight-1.7.0-2.rockspec
+++ b/rockspecs/penlight-1.7.0-2.rockspec
@@ -1,0 +1,70 @@
+package = "penlight"
+version = "1.7.0-2"
+
+source = {
+  url = "git+https://github.com/Tieske/Penlight.git",
+  branch = "1.7.0"
+}
+
+description = {
+  summary = "Lua utility libraries loosely based on the Python standard libraries",
+  homepage = "http://tieske.github.io/Penlight",
+  license = "MIT/X11",
+  maintainer = "thijs@thijsschreijer.nl",
+  detailed = [[
+Penlight is a set of pure Lua libraries for making it easier to work with common tasks like
+iterating over directories, reading configuration files and the like. Provides functional operations
+on tables and sequences.
+]]
+}
+
+dependencies = {
+  "luafilesystem",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["pl.strict"] = "lua/pl/strict.lua",
+    ["pl.dir"] = "lua/pl/dir.lua",
+    ["pl.operator"] = "lua/pl/operator.lua",
+    ["pl.input"] = "lua/pl/input.lua",
+    ["pl.config"] = "lua/pl/config.lua",
+    ["pl.compat"] = "lua/pl/config.lua",
+    ["pl.seq"] = "lua/pl/seq.lua",
+    ["pl.stringio"] = "lua/pl/stringio.lua",
+    ["pl.text"] = "lua/pl/text.lua",
+    ["pl.test"] = "lua/pl/test.lua",
+    ["pl.tablex"] = "lua/pl/tablex.lua",
+    ["pl.app"] = "lua/pl/app.lua",
+    ["pl.stringx"] = "lua/pl/stringx.lua",
+    ["pl.lexer"] = "lua/pl/lexer.lua",
+    ["pl.utils"] = "lua/pl/utils.lua",
+    ["pl.sip"] = "lua/pl/sip.lua",
+    ["pl.permute"] = "lua/pl/permute.lua",
+    ["pl.pretty"] = "lua/pl/pretty.lua",
+    ["pl.class"] = "lua/pl/class.lua",
+    ["pl.List"] = "lua/pl/List.lua",
+    ["pl.data"] = "lua/pl/data.lua",
+    ["pl.Date"] = "lua/pl/Date.lua",
+    ["pl.init"] = "lua/pl/init.lua",
+    ["pl.luabalanced"] = "lua/pl/luabalanced.lua",
+    ["pl.comprehension"] = "lua/pl/comprehension.lua",
+    ["pl.path"] = "lua/pl/path.lua",
+    ["pl.array2d"] = "lua/pl/array2d.lua",
+    ["pl.func"] = "lua/pl/func.lua",
+    ["pl.lapp"] = "lua/pl/lapp.lua",
+    ["pl.file"] = "lua/pl/file.lua",
+    ['pl.template'] = "lua/pl/template.lua",
+    ["pl.Map"] = "lua/pl/Map.lua",
+    ["pl.MultiMap"] = "lua/pl/MultiMap.lua",
+    ["pl.OrderedMap"] = "lua/pl/OrderedMap.lua",
+    ["pl.Set"] = "lua/pl/Set.lua",
+    ["pl.xml"] = "lua/pl/xml.lua",
+    ["pl.url"] = "lua/pl/url.lua",
+    ["pl.import_into"] = "lua/pl/import_into.lua",
+    ["pl.types"] = "lua/pl/types.lua",
+  },
+  copy_directories = {"docs", "tests"}
+}
+

--- a/rockspecs/penlight-1.8.0-2.rockspec
+++ b/rockspecs/penlight-1.8.0-2.rockspec
@@ -1,0 +1,70 @@
+package = "penlight"
+version = "1.8.0-2"
+
+source = {
+  url = "git+https://github.com/Tieske/Penlight.git",
+  branch = "1.8.0"
+}
+
+description = {
+  summary = "Lua utility libraries loosely based on the Python standard libraries",
+  homepage = "http://tieske.github.io/Penlight",
+  license = "MIT/X11",
+  maintainer = "thijs@thijsschreijer.nl",
+  detailed = [[
+Penlight is a set of pure Lua libraries for making it easier to work with common tasks like
+iterating over directories, reading configuration files and the like. Provides functional operations
+on tables and sequences.
+]]
+}
+
+dependencies = {
+  "luafilesystem",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["pl.strict"] = "lua/pl/strict.lua",
+    ["pl.dir"] = "lua/pl/dir.lua",
+    ["pl.operator"] = "lua/pl/operator.lua",
+    ["pl.input"] = "lua/pl/input.lua",
+    ["pl.config"] = "lua/pl/config.lua",
+    ["pl.compat"] = "lua/pl/config.lua",
+    ["pl.seq"] = "lua/pl/seq.lua",
+    ["pl.stringio"] = "lua/pl/stringio.lua",
+    ["pl.text"] = "lua/pl/text.lua",
+    ["pl.test"] = "lua/pl/test.lua",
+    ["pl.tablex"] = "lua/pl/tablex.lua",
+    ["pl.app"] = "lua/pl/app.lua",
+    ["pl.stringx"] = "lua/pl/stringx.lua",
+    ["pl.lexer"] = "lua/pl/lexer.lua",
+    ["pl.utils"] = "lua/pl/utils.lua",
+    ["pl.sip"] = "lua/pl/sip.lua",
+    ["pl.permute"] = "lua/pl/permute.lua",
+    ["pl.pretty"] = "lua/pl/pretty.lua",
+    ["pl.class"] = "lua/pl/class.lua",
+    ["pl.List"] = "lua/pl/List.lua",
+    ["pl.data"] = "lua/pl/data.lua",
+    ["pl.Date"] = "lua/pl/Date.lua",
+    ["pl.init"] = "lua/pl/init.lua",
+    ["pl.luabalanced"] = "lua/pl/luabalanced.lua",
+    ["pl.comprehension"] = "lua/pl/comprehension.lua",
+    ["pl.path"] = "lua/pl/path.lua",
+    ["pl.array2d"] = "lua/pl/array2d.lua",
+    ["pl.func"] = "lua/pl/func.lua",
+    ["pl.lapp"] = "lua/pl/lapp.lua",
+    ["pl.file"] = "lua/pl/file.lua",
+    ['pl.template'] = "lua/pl/template.lua",
+    ["pl.Map"] = "lua/pl/Map.lua",
+    ["pl.MultiMap"] = "lua/pl/MultiMap.lua",
+    ["pl.OrderedMap"] = "lua/pl/OrderedMap.lua",
+    ["pl.Set"] = "lua/pl/Set.lua",
+    ["pl.xml"] = "lua/pl/xml.lua",
+    ["pl.url"] = "lua/pl/url.lua",
+    ["pl.import_into"] = "lua/pl/import_into.lua",
+    ["pl.types"] = "lua/pl/types.lua",
+  },
+  copy_directories = {"docs", "tests"}
+}
+

--- a/rockspecs/penlight-1.8.1-2.rockspec
+++ b/rockspecs/penlight-1.8.1-2.rockspec
@@ -1,0 +1,70 @@
+package = "penlight"
+version = "1.8.1-2"
+
+source = {
+  url = "git+https://github.com/lunarmodules/Penlight.git",
+  tag = "1.8.1"
+}
+
+description = {
+  summary = "Lua utility libraries loosely based on the Python standard libraries",
+  homepage = "https://lunarmodules.github.io/Penlight",
+  license = "MIT/X11",
+  maintainer = "thijs@thijsschreijer.nl",
+  detailed = [[
+Penlight is a set of pure Lua libraries for making it easier to work with common tasks like
+iterating over directories, reading configuration files and the like. Provides functional operations
+on tables and sequences.
+]]
+}
+
+dependencies = {
+  "luafilesystem",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["pl.strict"] = "lua/pl/strict.lua",
+    ["pl.dir"] = "lua/pl/dir.lua",
+    ["pl.operator"] = "lua/pl/operator.lua",
+    ["pl.input"] = "lua/pl/input.lua",
+    ["pl.config"] = "lua/pl/config.lua",
+    ["pl.compat"] = "lua/pl/config.lua",
+    ["pl.seq"] = "lua/pl/seq.lua",
+    ["pl.stringio"] = "lua/pl/stringio.lua",
+    ["pl.text"] = "lua/pl/text.lua",
+    ["pl.test"] = "lua/pl/test.lua",
+    ["pl.tablex"] = "lua/pl/tablex.lua",
+    ["pl.app"] = "lua/pl/app.lua",
+    ["pl.stringx"] = "lua/pl/stringx.lua",
+    ["pl.lexer"] = "lua/pl/lexer.lua",
+    ["pl.utils"] = "lua/pl/utils.lua",
+    ["pl.sip"] = "lua/pl/sip.lua",
+    ["pl.permute"] = "lua/pl/permute.lua",
+    ["pl.pretty"] = "lua/pl/pretty.lua",
+    ["pl.class"] = "lua/pl/class.lua",
+    ["pl.List"] = "lua/pl/List.lua",
+    ["pl.data"] = "lua/pl/data.lua",
+    ["pl.Date"] = "lua/pl/Date.lua",
+    ["pl.init"] = "lua/pl/init.lua",
+    ["pl.luabalanced"] = "lua/pl/luabalanced.lua",
+    ["pl.comprehension"] = "lua/pl/comprehension.lua",
+    ["pl.path"] = "lua/pl/path.lua",
+    ["pl.array2d"] = "lua/pl/array2d.lua",
+    ["pl.func"] = "lua/pl/func.lua",
+    ["pl.lapp"] = "lua/pl/lapp.lua",
+    ["pl.file"] = "lua/pl/file.lua",
+    ['pl.template'] = "lua/pl/template.lua",
+    ["pl.Map"] = "lua/pl/Map.lua",
+    ["pl.MultiMap"] = "lua/pl/MultiMap.lua",
+    ["pl.OrderedMap"] = "lua/pl/OrderedMap.lua",
+    ["pl.Set"] = "lua/pl/Set.lua",
+    ["pl.xml"] = "lua/pl/xml.lua",
+    ["pl.url"] = "lua/pl/url.lua",
+    ["pl.import_into"] = "lua/pl/import_into.lua",
+    ["pl.types"] = "lua/pl/types.lua",
+  },
+  copy_directories = {"docs", "tests"}
+}
+

--- a/rockspecs/penlight-1.9.1-2.rockspec
+++ b/rockspecs/penlight-1.9.1-2.rockspec
@@ -1,0 +1,70 @@
+package = "penlight"
+version = "1.9.1-2"
+
+source = {
+  url = "git+https://github.com/lunarmodules/Penlight.git",
+  tag = "1.9.1"
+}
+
+description = {
+  summary = "Lua utility libraries loosely based on the Python standard libraries",
+  homepage = "https://lunarmodules.github.io/Penlight",
+  license = "MIT/X11",
+  maintainer = "thijs@thijsschreijer.nl",
+  detailed = [[
+Penlight is a set of pure Lua libraries for making it easier to work with common tasks like
+iterating over directories, reading configuration files and the like. Provides functional operations
+on tables and sequences.
+]]
+}
+
+dependencies = {
+  "luafilesystem",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["pl.strict"] = "lua/pl/strict.lua",
+    ["pl.dir"] = "lua/pl/dir.lua",
+    ["pl.operator"] = "lua/pl/operator.lua",
+    ["pl.input"] = "lua/pl/input.lua",
+    ["pl.config"] = "lua/pl/config.lua",
+    ["pl.compat"] = "lua/pl/config.lua",
+    ["pl.seq"] = "lua/pl/seq.lua",
+    ["pl.stringio"] = "lua/pl/stringio.lua",
+    ["pl.text"] = "lua/pl/text.lua",
+    ["pl.test"] = "lua/pl/test.lua",
+    ["pl.tablex"] = "lua/pl/tablex.lua",
+    ["pl.app"] = "lua/pl/app.lua",
+    ["pl.stringx"] = "lua/pl/stringx.lua",
+    ["pl.lexer"] = "lua/pl/lexer.lua",
+    ["pl.utils"] = "lua/pl/utils.lua",
+    ["pl.sip"] = "lua/pl/sip.lua",
+    ["pl.permute"] = "lua/pl/permute.lua",
+    ["pl.pretty"] = "lua/pl/pretty.lua",
+    ["pl.class"] = "lua/pl/class.lua",
+    ["pl.List"] = "lua/pl/List.lua",
+    ["pl.data"] = "lua/pl/data.lua",
+    ["pl.Date"] = "lua/pl/Date.lua",
+    ["pl.init"] = "lua/pl/init.lua",
+    ["pl.luabalanced"] = "lua/pl/luabalanced.lua",
+    ["pl.comprehension"] = "lua/pl/comprehension.lua",
+    ["pl.path"] = "lua/pl/path.lua",
+    ["pl.array2d"] = "lua/pl/array2d.lua",
+    ["pl.func"] = "lua/pl/func.lua",
+    ["pl.lapp"] = "lua/pl/lapp.lua",
+    ["pl.file"] = "lua/pl/file.lua",
+    ['pl.template'] = "lua/pl/template.lua",
+    ["pl.Map"] = "lua/pl/Map.lua",
+    ["pl.MultiMap"] = "lua/pl/MultiMap.lua",
+    ["pl.OrderedMap"] = "lua/pl/OrderedMap.lua",
+    ["pl.Set"] = "lua/pl/Set.lua",
+    ["pl.xml"] = "lua/pl/xml.lua",
+    ["pl.url"] = "lua/pl/url.lua",
+    ["pl.import_into"] = "lua/pl/import_into.lua",
+    ["pl.types"] = "lua/pl/types.lua",
+  },
+  copy_directories = {"docs", "tests"}
+}
+

--- a/rockspecs/penlight-1.9.2-2.rockspec
+++ b/rockspecs/penlight-1.9.2-2.rockspec
@@ -1,0 +1,70 @@
+package = "penlight"
+version = "1.9.2-2"
+
+source = {
+  url = "git+https://github.com/lunarmodules/Penlight.git",
+  tag = "1.9.2"
+}
+
+description = {
+  summary = "Lua utility libraries loosely based on the Python standard libraries",
+  homepage = "https://lunarmodules.github.io/Penlight",
+  license = "MIT/X11",
+  maintainer = "thijs@thijsschreijer.nl",
+  detailed = [[
+Penlight is a set of pure Lua libraries for making it easier to work with common tasks like
+iterating over directories, reading configuration files and the like. Provides functional operations
+on tables and sequences.
+]]
+}
+
+dependencies = {
+  "luafilesystem",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["pl.strict"] = "lua/pl/strict.lua",
+    ["pl.dir"] = "lua/pl/dir.lua",
+    ["pl.operator"] = "lua/pl/operator.lua",
+    ["pl.input"] = "lua/pl/input.lua",
+    ["pl.config"] = "lua/pl/config.lua",
+    ["pl.compat"] = "lua/pl/config.lua",
+    ["pl.seq"] = "lua/pl/seq.lua",
+    ["pl.stringio"] = "lua/pl/stringio.lua",
+    ["pl.text"] = "lua/pl/text.lua",
+    ["pl.test"] = "lua/pl/test.lua",
+    ["pl.tablex"] = "lua/pl/tablex.lua",
+    ["pl.app"] = "lua/pl/app.lua",
+    ["pl.stringx"] = "lua/pl/stringx.lua",
+    ["pl.lexer"] = "lua/pl/lexer.lua",
+    ["pl.utils"] = "lua/pl/utils.lua",
+    ["pl.sip"] = "lua/pl/sip.lua",
+    ["pl.permute"] = "lua/pl/permute.lua",
+    ["pl.pretty"] = "lua/pl/pretty.lua",
+    ["pl.class"] = "lua/pl/class.lua",
+    ["pl.List"] = "lua/pl/List.lua",
+    ["pl.data"] = "lua/pl/data.lua",
+    ["pl.Date"] = "lua/pl/Date.lua",
+    ["pl.init"] = "lua/pl/init.lua",
+    ["pl.luabalanced"] = "lua/pl/luabalanced.lua",
+    ["pl.comprehension"] = "lua/pl/comprehension.lua",
+    ["pl.path"] = "lua/pl/path.lua",
+    ["pl.array2d"] = "lua/pl/array2d.lua",
+    ["pl.func"] = "lua/pl/func.lua",
+    ["pl.lapp"] = "lua/pl/lapp.lua",
+    ["pl.file"] = "lua/pl/file.lua",
+    ['pl.template'] = "lua/pl/template.lua",
+    ["pl.Map"] = "lua/pl/Map.lua",
+    ["pl.MultiMap"] = "lua/pl/MultiMap.lua",
+    ["pl.OrderedMap"] = "lua/pl/OrderedMap.lua",
+    ["pl.Set"] = "lua/pl/Set.lua",
+    ["pl.xml"] = "lua/pl/xml.lua",
+    ["pl.url"] = "lua/pl/url.lua",
+    ["pl.import_into"] = "lua/pl/import_into.lua",
+    ["pl.types"] = "lua/pl/types.lua",
+  },
+  copy_directories = {"docs", "tests"}
+}
+


### PR DESCRIPTION
GitHub has completely blocked access to pull over insecure over-the-wire protocols including http:// and git://.

I'm not quite sure how to handle all the historical rockspecs. They could be left in a broken state or (as this currently does) we can fix them in place and just not worry about bumping the rockrel so that they are usable for direct testing (say from a CI job that loads old versions directly from the rockspecs).
