### PR TITLE
chore(ci) Utilize new upstream Luacheck Action

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -3,21 +3,11 @@ name: Luacheck
 on: [push, pull_request]
 
 jobs:
-  luacheck:
-    runs-on: ubuntu-latest
 
+  luacheck:
+    runs-on: ubuntu-20.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup Lua
-      uses: leafo/gh-actions-lua@v8
-      with:
-        luaVersion: 5.4
-    - name: Setup Lua Rocks
-      uses: leafo/gh-actions-luarocks@v4
-    - name: Setup dependencies
-      run: luarocks install luacheck
-    - name: Run Code Linter
-      run: |
-        luacheck .
-        luarocks lint *.rockspec
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Luacheck
+        uses: lunarmodules/luacheck@v0


### PR DESCRIPTION
As of v0.26.0, the Luacheck repository is enabled to run *as* a GH
Action so there is no need to install Lua, LuaRocks, then the linter,
etc. Just one `uses:`.

This also removes Luarocks rockspec linter, but I think that belongs in
an altogether different place in the workflow(s).
