### PR TITLE
fix(lapp) add file name to arg table when using the default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    [#413](https://github.com/lunarmodules/Penlight/pull/413)
  - feat: `utils.kpairs` new iterator over all non-integer keys
    [#413](https://github.com/lunarmodules/Penlight/pull/413)
-- fix: `lapp` provides the file name when using the default argument
+ - fix: `lapp` provides the file name when using the default argument
    [#427](https://github.com/lunarmodules/Penlight/pull/427)
 
 ## 1.12.0 (2022-Jan-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,293 +7,295 @@ deprecation policy.
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
 ## 1.13.0 (unreleased)
-
-- fix: `compat.warn` raised write guard warning in OpenResty
+ - fix: `compat.warn` raised write guard warning in OpenResty
    [#414](https://github.com/lunarmodules/Penlight/pull/414)
-- feat: `utils.enum` now accepts hash tables, to enable better error handling
+ - feat: `utils.enum` now accepts hash tables, to enable better error handling
    [#413](https://github.com/lunarmodules/Penlight/pull/413)
-- feat: `utils.kpairs` new iterator over all non-integer keys
+ - feat: `utils.kpairs` new iterator over all non-integer keys
    [#413](https://github.com/lunarmodules/Penlight/pull/413)
 - fix: `lapp` provides the file name when using the default argument
    [#427](https://github.com/lunarmodules/Penlight/pull/427)
 
 ## 1.12.0 (2022-Jan-10)
-
-- deprecate: module `pl.text` the contents have moved to `pl.stringx` (removal later)
+ - deprecate: module `pl.text` the contents have moved to `pl.stringx` (removal later)
    [#407](https://github.com/lunarmodules/Penlight/pull/407)
-- deprecate: module `pl.xml`, please switch to a more specialized library (removal later)
+ - deprecate: module `pl.xml`, please switch to a more specialized library (removal later)
    [#409](https://github.com/lunarmodules/Penlight/pull/409)
-- feat: `utils.npairs` added. An iterator with a range that honours the `n` field
+ - feat: `utils.npairs` added. An iterator with a range that honours the `n` field
    [#387](https://github.com/lunarmodules/Penlight/pull/387)
-- fix: `xml.maptags` would hang if it encountered text-nodes
+ - fix: `xml.maptags` would hang if it encountered text-nodes
    [#396](https://github.com/lunarmodules/Penlight/pull/396)
-- fix: `text.dedent` didn't handle declining indents nor empty lines
+ - fix: `text.dedent` didn't handle declining indents nor empty lines
    [#402](https://github.com/lunarmodules/Penlight/pull/402)
-- fix: `dir.getfiles`, `dir.getdirectories`, and `dir.getallfiles` now have the
+ - fix: `dir.getfiles`, `dir.getdirectories`, and `dir.getallfiles` now have the
    directory optional, as was already documented
    [#405](https://github.com/lunarmodules/Penlight/pull/405)
-- feat: `array2d.default_range` now also takes a spreadsheet range, which means
+ - feat: `array2d.default_range` now also takes a spreadsheet range, which means
    also other functions now take a range. [#404](https://github.com/lunarmodules/Penlight/pull/404)
-- fix: `lapp` enums allow [patterns magic characters](https://www.lua.org/pil/20.2.html)
+ - fix: `lapp` enums allow [patterns magic characters](https://www.lua.org/pil/20.2.html)
    [#393](https://github.com/lunarmodules/Penlight/pull/393)
-- fix: `text.wrap` and `text.fill` numerous fixes for handling whitespace,
+ - fix: `text.wrap` and `text.fill` numerous fixes for handling whitespace,
    accented characters, honouring width, etc.
    [#400](https://github.com/lunarmodules/Penlight/pull/400)
-- feat: `text.wrap` and `text.fill` have a new parameter to forcefully break words
+ - feat: `text.wrap` and `text.fill` have a new parameter to forcefully break words
    longer than the width given.
    [#400](https://github.com/lunarmodules/Penlight/pull/400)
-- fix: `stringx.expandtabs` could error out on Lua 5.3+
+ - fix: `stringx.expandtabs` could error out on Lua 5.3+
    [#406](https://github.com/lunarmodules/Penlight/pull/406)
-- fix: `pl` the module would not properly forward the `newindex` metamethod
+ - fix: `pl` the module would not properly forward the `newindex` metamethod
    on the global table.
    [#395](https://github.com/lunarmodules/Penlight/pull/395)
-- feat: `utils.enum` added to create enums and prevent magic strings
+ - feat: `utils.enum` added to create enums and prevent magic strings
    [#408](https://github.com/lunarmodules/Penlight/pull/408)
-- change: `xml.new` added some sanity checks on input
+ - change: `xml.new` added some sanity checks on input
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
-- added: `xml.xml_escape` and `xml.xml_unescape` functions (previously private)
+ - added: `xml.xml_escape` and `xml.xml_unescape` functions (previously private)
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
-- feat: `xml.tostring` now also takes numeric indents (previously only strings)
+ - feat: `xml.tostring` now also takes numeric indents (previously only strings)
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
-- fix: `xml.walk` now detects recursion (errors out)
+ - fix: `xml.walk` now detects recursion (errors out)
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
-- fix: `xml.clone` now detects recursion (errors out)
+ - fix: `xml.clone` now detects recursion (errors out)
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
-- fix: `xml.compare` now detects recursion (errors out)
+ - fix: `xml.compare` now detects recursion (errors out)
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
-- fix: `xml.compare` text compares now work
+ - fix: `xml.compare` text compares now work
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
-- fix: `xml.compare` attribute order compares now only compare if both inputs provide an order
+ - fix: `xml.compare` attribute order compares now only compare if both inputs provide an order
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
-- fix: `xml.compare` child comparisons failing now report proper error
+ - fix: `xml.compare` child comparisons failing now report proper error
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
+
 
 ## 1.11.0 (2021-Aug-18)
 
-- fix: `stringx.strip` behaved badly with string lengths > 200
+ - fix: `stringx.strip` behaved badly with string lengths > 200
    [#382](https://github.com/lunarmodules/Penlight/pull/382)
-- fix: `path.currentdir` now takes no arguments and calls `lfs.currentdir` without argument
+ - fix: `path.currentdir` now takes no arguments and calls `lfs.currentdir` without argument
    [#383](https://github.com/lunarmodules/Penlight/pull/383)
-- feat: `utils.raise_deprecation` now has an option to NOT include a
+ - feat: `utils.raise_deprecation` now has an option to NOT include a
    stack-trace [#385](https://github.com/lunarmodules/Penlight/pull/385)
+
 
 ## 1.10.0 (2021-Apr-27)
 
-- deprecate: `permute.iter`, renamed to `permute.order_iter` (removal later)
+ - deprecate: `permute.iter`, renamed to `permute.order_iter` (removal later)
    [#360](https://github.com/lunarmodules/Penlight/pull/360)
-- deprecate: `permute.table`, renamed to `permute.order_table` (removal later)
+ - deprecate: `permute.table`, renamed to `permute.order_table` (removal later)
    [#360](https://github.com/lunarmodules/Penlight/pull/360)
-- deprecate: `Date` module (removal later)
+ - deprecate: `Date` module (removal later)
    [#367](https://github.com/lunarmodules/Penlight/pull/367)
-- feat: `permute.list_iter` to iterate over different sets of values
+ - feat: `permute.list_iter` to iterate over different sets of values
    [#360](https://github.com/lunarmodules/Penlight/pull/360)
-- feat: `permute.list_table` generate table with different sets of values
+ - feat: `permute.list_table` generate table with different sets of values
    [#360](https://github.com/lunarmodules/Penlight/pull/360)
-- feat: Lua 5.4 'warn' compatibility function
+ - feat: Lua 5.4 'warn' compatibility function
    [#366](https://github.com/lunarmodules/Penlight/pull/366)
-- feat: deprecation functionality `utils.raise_deprecation`
+ - feat: deprecation functionality `utils.raise_deprecation`
    [#361](https://github.com/lunarmodules/Penlight/pull/361)
-- feat: `utils.splitv` now takes same args as `split`
+ - feat: `utils.splitv` now takes same args as `split`
    [#373](https://github.com/lunarmodules/Penlight/pull/373)
-- fix: `dir.rmtree` failed to remove symlinks to directories
+ - fix: `dir.rmtree` failed to remove symlinks to directories
    [#365](https://github.com/lunarmodules/Penlight/pull/365)
-- fix: `pretty.write` could error out on failing metamethods (Lua 5.3+)
+ - fix: `pretty.write` could error out on failing metamethods (Lua 5.3+)
    [#368](https://github.com/lunarmodules/Penlight/pull/368)
-- fix: `app.parse` now correctly parses values containing '=' or ':'
+ - fix: `app.parse` now correctly parses values containing '=' or ':'
    [#373](https://github.com/lunarmodules/Penlight/pull/373)
-- fix: `dir.makepath` failed to create top-level directories
+ - fix: `dir.makepath` failed to create top-level directories
    [#372](https://github.com/lunarmodules/Penlight/pull/372)
-- overhaul: `array2d` module was updated, got additional tests and several
+ - overhaul: `array2d` module was updated, got additional tests and several
    documentation updates
    [#377](https://github.com/lunarmodules/Penlight/pull/377)
-- feat: `aray2d` now accepts negative indices
-- feat: `array2d.row` added to align with `column`
-- fix: bad error message in `array2d.map`
-- fix: `array2d.flatten` now ensures to deliver a 'square' result if `nil` is
+ - feat: `aray2d` now accepts negative indices
+ - feat: `array2d.row` added to align with `column`
+ - fix: bad error message in `array2d.map`
+ - fix: `array2d.flatten` now ensures to deliver a 'square' result if `nil` is
    encountered
-- feat: `array2d.transpose` added
-- feat: `array2d.swap_rows` and `array2d.swap_cols` now return the array
-- fix: `aray2d.range` correctly recognizes `R` column in spreadsheet format, was
+ - feat: `array2d.transpose` added
+ - feat: `array2d.swap_rows` and `array2d.swap_cols` now return the array
+ - fix: `aray2d.range` correctly recognizes `R` column in spreadsheet format, was
    mistaken for `R1C1` format.
-- fix: `aray2d.range` correctly recognizes 2 char column in spreadsheet format
-- feat: `array2d.default_range` added (previously private)
-- feat: `array2d.set` if used with a function now passes `i,j` to the function
+ - fix: `aray2d.range` correctly recognizes 2 char column in spreadsheet format
+ - feat: `array2d.default_range` added (previously private)
+ - feat: `array2d.set` if used with a function now passes `i,j` to the function
    in line with the `new` implementation.
-- fix: `array2d.iter` didn't properly iterate the indices
+ - fix: `array2d.iter` didn't properly iterate the indices
    [#376](https://github.com/lunarmodules/Penlight/issues/376)
-- feat: `array2d.columns` now returns a second value; the column index
-- feat: `array2d.rows` added to be in line with `columns`
+ - feat: `array2d.columns` now returns a second value; the column index
+ - feat: `array2d.rows` added to be in line with `columns`
+
 
 ## 1.9.2 (2020-Sep-27)
 
-- fix: dir.walk [#350](https://github.com/lunarmodules/Penlight/pull/350)
+ - fix: dir.walk [#350](https://github.com/lunarmodules/Penlight/pull/350)
+
 
 ## 1.9.1 (2020-Sep-24)
 
-- released to superseed the 1.9.0 version which was retagged in git after some
+ - released to superseed the 1.9.0 version which was retagged in git after some
    distro's already had picked it up. This version is identical to 1.8.1.
 
 ## 1.8.1 (2020-Sep-24) (replacing a briefly released but broken 1.9.0 version)
 
 ## Fixes
 
-- In `pl.class`, `_init` can now be inherited from grandparent (or older ancestor) classes. [#289](https://github.com/lunarmodules/Penlight/pull/289)
-- Fixes `dir`, `lexer`, and `permute` to no longer use coroutines. [#344](https://github.com/lunarmodules/Penlight/pull/344)
+  - In `pl.class`, `_init` can now be inherited from grandparent (or older ancestor) classes. [#289](https://github.com/lunarmodules/Penlight/pull/289)
+  - Fixes `dir`, `lexer`, and `permute` to no longer use coroutines. [#344](https://github.com/lunarmodules/Penlight/pull/344)
 
 ## 1.8.0 (2020-Aug-05)
 
 ### New features
 
-- `pretty.debug` quickly dumps a set of values to stdout for debug purposes
+  - `pretty.debug` quickly dumps a set of values to stdout for debug purposes
 
 ### Changes
 
-- `pretty.write`: now also sorts non-string keys [#319](https://github.com/lunarmodules/Penlight/pull/319)
-- `stringx.count` has an extra option to allow overlapping matches
+  - `pretty.write`: now also sorts non-string keys [#319](https://github.com/lunarmodules/Penlight/pull/319)
+  - `stringx.count` has an extra option to allow overlapping matches
     [#326](https://github.com/lunarmodules/Penlight/pull/326)
-- added an extra changelog entry for `types.is_empty` on the 1.6.0 changelog, due
+  - added an extra changelog entry for `types.is_empty` on the 1.6.0 changelog, due
     to additional fixed behaviour not called out appropriately [#313](https://github.com/lunarmodules/Penlight/pull/313)
-- `path.packagepath` now returns a proper error message with names tried if
+  - `path.packagepath` now returns a proper error message with names tried if
     it fails
 
 ### Fixes
 
-- Fix: `stringx.rfind` now properly works with overlapping matches
+  - Fix: `stringx.rfind` now properly works with overlapping matches
     [#314](https://github.com/lunarmodules/Penlight/pull/314)
-- Fix: `package.searchpath` (in module `pl.compat`)
+  - Fix: `package.searchpath` (in module `pl.compat`)
     [#328](https://github.com/lunarmodules/Penlight/pull/328)
-- Fix: `path.isabs` now reports drive + relative-path as `false`, eg. "c:some/path" (Windows only)
-- Fix: OpenResty coroutines, used by `dir.dirtree`, `pl.lexer`, `pl.permute`. If
+  - Fix: `path.isabs` now reports drive + relative-path as `false`, eg. "c:some/path" (Windows only)
+  - Fix: OpenResty coroutines, used by `dir.dirtree`, `pl.lexer`, `pl.permute`. If
     available the original coroutine functions are now used [#329](https://github.com/lunarmodules/Penlight/pull/329)
-- Fix: in `pl.strict` also predefine global `_PROMPT2`
-- Fix: in `pl.strict` apply `tostring` to the given name, in case it is not a string.
-- Fix: the lexer would not recognize numbers without leading zero; "-.123".
+  - Fix: in `pl.strict` also predefine global `_PROMPT2`
+  - Fix: in `pl.strict` apply `tostring` to the given name, in case it is not a string.
+  - Fix: the lexer would not recognize numbers without leading zero; "-.123".
     See [#315](https://github.com/lunarmodules/Penlight/issues/315)
 
 ## 1.7.0 (2019-Oct-14)
 
 ### New features
 
-- `utils.quote_arg` will now optionally take an array of arguments and escape
+  - `utils.quote_arg` will now optionally take an array of arguments and escape
     them all into a single string.
-- `app.parse_args` now accepts a 3rd parameter with a list of valid flags and aliasses
-- `app.script_name` returns the name of the current script (previously a private function)
+  - `app.parse_args` now accepts a 3rd parameter with a list of valid flags and aliasses
+  - `app.script_name` returns the name of the current script (previously a private function)
 
 ### Changes
 
-- Documentation updates
-- `utils.quit`: exit message is no longer required, and closes the Lua state (on 5.2+).
-- `utils.assert_arg` and `utils.assert_string`: now return the validated value
-- `pl.compat`: now exports the `jit` and `jit52` flags
-- `pretty.write`: now sorts the output for easier diffs [#293](https://github.com/lunarmodules/Penlight/pull/293)
+  - Documentation updates
+  - `utils.quit`: exit message is no longer required, and closes the Lua state (on 5.2+).
+  - `utils.assert_arg` and `utils.assert_string`: now return the validated value
+  - `pl.compat`: now exports the `jit` and `jit52` flags
+  - `pretty.write`: now sorts the output for easier diffs [#293](https://github.com/lunarmodules/Penlight/pull/293)
 
 ### Fixes
 
-- `utils.raise` changed the global `on_error`-level when passing in bad arguments
-- `utils.writefile` now checks and returns errors when writing
-- `compat.execute` now handles the Windows exitcode -1 properly
-- `types.is_empty` would return true on spaces always, independent of the parameter
-- `types.to_bool` will now compare case-insensitive for the extra passed strings
-- `app.require_here` will now properly handle an absolute base path
-- `stringx.split` will no longer append an empty match if the number of requested
+  - `utils.raise` changed the global `on_error`-level when passing in bad arguments
+  - `utils.writefile` now checks and returns errors when writing
+  - `compat.execute` now handles the Windows exitcode -1 properly
+  - `types.is_empty` would return true on spaces always, independent of the parameter
+  - `types.to_bool` will now compare case-insensitive for the extra passed strings
+  - `app.require_here` will now properly handle an absolute base path
+  - `stringx.split` will no longer append an empty match if the number of requested
     elements has already been reached [#295](https://github.com/lunarmodules/Penlight/pull/295)
-- `path.common_prefix` and `path.relpath` return the result in the original casing
+  - `path.common_prefix` and `path.relpath` return the result in the original casing
     (only impacted Windows) [#297](https://github.com/lunarmodules/Penlight/pull/297)
-- `dir.copyfile`, `dir.movefile`, and `dir.makepath` create the new file/path with
+  - `dir.copyfile`, `dir.movefile`, and `dir.makepath` create the new file/path with
     the requested casing, and no longer force lowercase (only impacted Windows)
     [#297](https://github.com/lunarmodules/Penlight/pull/297)
-- added a missing assertion on `path.getmtime` [#291](https://github.com/lunarmodules/Penlight/pull/291)
-- `stringx.rpartition` returned bad results on a not-found [#299](https://github.com/lunarmodules/Penlight/pull/299)
+  - added a missing assertion on `path.getmtime` [#291](https://github.com/lunarmodules/Penlight/pull/291)
+  - `stringx.rpartition` returned bad results on a not-found [#299](https://github.com/lunarmodules/Penlight/pull/299)
 
 ## 1.6.0 (2018-Nov-23)
 
 ### New features
 
-- `pl.compat` now provides `unpack` as `table.unpack` on Lua 5.1
+  - `pl.compat` now provides `unpack` as `table.unpack` on Lua 5.1
 
 ### Changes
 
-- `utils.unpack` is now documented and respects `.n` field of its argument.
-- `tablex.deepcopy` and `tablex.deepcompare` are now cycle aware (#262)
-- Installing through LuaRocks will now include the full rendered documentation
+  - `utils.unpack` is now documented and respects `.n` field of its argument.
+  - `tablex.deepcopy` and `tablex.deepcompare` are now cycle aware (#262)
+  - Installing through LuaRocks will now include the full rendered documentation
 
 ### Fixes
 
-- Fixed `seq.last` returning `nil` instead of an empty list when given an empty iterator (#253).
-- `pl.template` now applies `tostring` when substituting values in templates, avoiding errors when they are not strings or numbers (#256).
-- Fixed `pl.import_into` not importing some Penlight modules (#268).
-- Fixed version number stuck at 1.5.2 (#260).
-- Fixed `types.is_empty` returning `true` on tables containing `false` key (#267).
-- Fixed `types.is_empty` returning `false` if not a nil/table/string
-- Fixed `test.assertraise` throwing an error when passed an array with a function to call plus its arguments (#272).
-- Fixed `test.assertraise` not throwing an error when given function does not error but instead returns a string matching given error pattern.
-- Fixed placeholder expressions being evaluated with wrong precedence of binary and unary negation.
-- Fixed placeholder expressions being evaluated assuming wrong binary operator associativity (e.g. `_1-(_2+_3)` was evaluated as `(_1-_2)+_3`.
-- Fixed placeholder expressions being evaluated as if unary operators take precedence over power operator (e.g. `(-_1)^_2`) was evaluated as `-(_1^2)`).
-- Fixed vulnerable backtracking pattern in `pl.stringx.strip` (#275)
+  - Fixed `seq.last` returning `nil` instead of an empty list when given an empty iterator (#253).
+  - `pl.template` now applies `tostring` when substituting values in templates, avoiding errors when they are not strings or numbers (#256).
+  - Fixed `pl.import_into` not importing some Penlight modules (#268).
+  - Fixed version number stuck at 1.5.2 (#260).
+  - Fixed `types.is_empty` returning `true` on tables containing `false` key (#267).
+  - Fixed `types.is_empty` returning `false` if not a nil/table/string
+  - Fixed `test.assertraise` throwing an error when passed an array with a function to call plus its arguments (#272).
+  - Fixed `test.assertraise` not throwing an error when given function does not error but instead returns a string matching given error pattern.
+  - Fixed placeholder expressions being evaluated with wrong precedence of binary and unary negation.
+  - Fixed placeholder expressions being evaluated assuming wrong binary operator associativity (e.g. `_1-(_2+_3)` was evaluated as `(_1-_2)+_3`.
+  - Fixed placeholder expressions being evaluated as if unary operators take precedence over power operator (e.g. `(-_1)^_2`) was evaluated as `-(_1^2)`).
+  - Fixed vulnerable backtracking pattern in `pl.stringx.strip` (#275)
 
 ## 1.5.4 (2017-07-17)
 
 ### Fixes
 
-- Fixed `compat.execute` behaving differently on Lua 5.1 and 5.1+.
-- Fixed `lapp.process_options_string` setting global `success` variable.
+  - Fixed `compat.execute` behaving differently on Lua 5.1 and 5.1+.
+  - Fixed `lapp.process_options_string` setting global `success` variable.
 
 ## 1.5.3 (2017-07-16)
 
 ### Changes
 
-- Added `template.compile` function that allows caching compiled template and rendering it multiple times.
-- Added special `_debug` field to environment table argument in `template.substitute` for printing generated template code upon render error.
+  - Added `template.compile` function that allows caching compiled template and rendering it multiple times.
+  - Added special `_debug` field to environment table argument in `template.substitute` for printing generated template code upon render error.
 
 ### Fixes
 
-- Fixed error (`attempt to concatenate a nil value (local 'vtype')`) in `lapp.process_options_string`.
+  - Fixed error (`attempt to concatenate a nil value (local 'vtype')`) in `lapp.process_options_string`.
 
 ## 1.5.2 (2017-04-08)
 
 ### Fixes
 
-- Removed leftover debug pring in `lapp.process_options_string`.
+  - Removed leftover debug pring in `lapp.process_options_string`.
 
 ## 1.5.1 (2017-04-02)
 
 ### Fixes
 
-- Fixed `dir.getfiles` matching given pattern against full paths from base directory instead of file names.
+  - Fixed `dir.getfiles` matching given pattern against full paths from base directory instead of file names.
 
 ## 1.5.0 (2017-04-01)
 
 ### Changes
 
-- `stringx.splitlines` considers `\r\n` a single line ending.
-- `stringx.splitlines` returns an empty list for an empty string.
+  - `stringx.splitlines` considers `\r\n` a single line ending.
+  - `stringx.splitlines` returns an empty list for an empty string.
 
 ### Fixes
 
-- `tablex.count_map` no longer raises an error.
-- `strict.module` correctly handles existing `__index` metamethod returning `false`.
-- `app.parse_args` accepts colon as a separator between option name and value, as advertised.
-- `pretty.load` handles case where a C hook is present.
+  - `tablex.count_map` no longer raises an error.
+  - `strict.module` correctly handles existing `__index` metamethod returning `false`.
+  - `app.parse_args` accepts colon as a separator between option name and value, as advertised.
+  - `pretty.load` handles case where a C hook is present.
   ' `os.execute` had issue with LuaJIT in 5.2 compat mode.
 
 ### Features
 
-- `template` supports customizing inline escape character and chunk name.
-- `seq` constructor supports iterators with a state object as the second argument.
-- `stringx.splitlines` has `keep_ends` argument.
-- `tablex.reduce` can take an optional initial value.
+  - `template` supports customizing inline escape character and chunk name.
+  - `seq` constructor supports iterators with a state object as the second argument.
+  - `stringx.splitlines` has `keep_ends` argument.
+  - `tablex.reduce` can take an optional initial value.
 
 ## 1.4.1 (2016-08-16)
 
 ### Changes
 
-- All functions that return instances of `pl.List`, `pl.Map` and `pl.Set` now require corresponding modules,
+  - All functions that return instances of `pl.List`, `pl.Map` and `pl.Set` now require corresponding modules,
    so that their methods always work right away.
 
 ### Fixes
 
-- Fixed `dir.getallfiles` returning an empty array when called without `pattern` argument.
+  - Fixed `dir.getallfiles` returning an empty array when called without `pattern` argument.
 
 ### Features
 
@@ -303,62 +305,63 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
 
 ### Fixes
 
-- `pl.path` covers edge cases better (e.g `path.normpath` was broken)
-- `p.dir` shell patterns fixed
-- `os.tmpname` broken on modern Windows/MSVC14
-- (likewise for `utils.executeex` which depends on it)
-- `pretty.write` more robust and does not lose floating-point precision;
+  - `pl.path` covers edge cases better (e.g `path.normpath` was broken)
+  - `p.dir` shell patterns fixed
+  - `os.tmpname` broken on modern Windows/MSVC14
+  - (likewise for `utils.executeex` which depends on it)
+  - `pretty.write` more robust and does not lose floating-point precision;
     saves and restores debug hooks when loading.
-- `pl.lexer` fixes: `cpp` lexer now filters space by default
-- `tablex.sortv` no longer assumes that the values are all unique
-- `stringx.center` is now consistent with Python; `stringx.rfind` and
+  - `pl.lexer` fixes: `cpp` lexer now filters space by default
+  - `tablex.sortv` no longer assumes that the values are all unique
+  - `stringx.center` is now consistent with Python; `stringx.rfind` and
   `string.quote_string` fixed.
-- `data.write` had a problem with default delimiter, properly returns error now.
-- `pl.Set` `+` and `-` now have correct semantics
+  - `data.write` had a problem with default delimiter, properly returns error now.
+  - `pl.Set` `+` and `-` now have correct semantics
 
 ### Features
 
-- `pl.tablex` has `union` and `merge` convenience functions
-- `pl.lapp` understands '--' meaning end of parsed arguments
-- `utils.quote_arg` quotes command arguments for `os.execute`,
+  - `pl.tablex` has `union` and `merge` convenience functions
+  - `pl.lapp` understands '--' meaning end of parsed arguments
+  - `utils.quote_arg` quotes command arguments for `os.execute`,
   correctly handling all special characters.
-- `utils.writefile` has optional `is_bin` argument
-- 'pl.lexer' supports line numbers with string argument
-- `stringx.endswith` may be passed an array of possible suffixes.
-- `data.read` - in CSV mode, assume empty fields are numerical zero
+  - `utils.writefile` has optional `is_bin` argument
+  - 'pl.lexer' supports line numbers with string argument
+  - `stringx.endswith` may be passed an array of possible suffixes.
+  - `data.read` - in CSV mode, assume empty fields are numerical zero
+
 
 ## 1.3.2 (2015-05-10)
 
 ### Changes
 
-- now works and passes tests with Lua 5.3
-- utils.import will NOT override global symbols (import 'math' caused global type() to be clobbered)
-- Updated pl.dir.file_op to return true on success and false on failure...
-- workaround for issues with pl.lapp with amalg.lua - will look at global LAPP_SCRIPT if arg[0] is nil
+  - now works and passes tests with Lua 5.3
+  - utils.import will NOT override global symbols (import 'math' caused global type() to be clobbered)
+  - Updated pl.dir.file_op to return true on success and false on failure...
+  - workaround for issues with pl.lapp with amalg.lua - will look at global LAPP_SCRIPT if arg[0] is nil
 
 ### Fixes
 
-- func was broken: do NOT use ipairs to iterate if __index is overriden!
-- issue #133 pretty.read (naively) confused by unbalanced brackets
-- xml attribute underscore fix for simple parser
-- Fix path.normpath
-- lexer: fix parsing block comments/string. fix hang on empty string.
-- Fixed utils.execute returning different values for Lua 5.1 and Lua 5.2
-- Issue #97; fixed attempt to put a month into a day
-- problem with tablex.count_map with custom comparison
-- tablex.pairmap overwrites result if key already exists; instead, upon detection that key already exists
- for a returned value, we modify the key's value to be a table and insert values into that table
+  - func was broken: do NOT use ipairs to iterate if __index is overriden!
+  - issue #133 pretty.read (naively) confused by unbalanced brackets
+  - xml attribute underscore fix for simple parser
+  - Fix path.normpath
+  - lexer: fix parsing block comments/string. fix hang on empty string.
+  -  Fixed utils.execute returning different values for Lua 5.1 and Lua 5.2
+  - Issue #97; fixed attempt to put a month into a day
+  -  problem with tablex.count_map with custom comparison
+  - tablex.pairmap overwrites result if key already exists; instead, upon detection that key already exists
+	for a returned value, we modify the key's value to be a table and insert values into that table
 
 ### Features
 
-- Add Python style url module for quote and unquote.
-- stringx.quote_string, which scans for embedded long-string quote matches and escapes them by creating a long-string quote.
-- issue #117: tablex.range now works with decreasing numbers, consistent with numerical for loop
-- utils.import will NOT override global symbols (import 'math' caused global type() to be clobbered)
-- issue #125: DOCTYPE ignored in xml documents as well
-- Allow XML tostring() function to customize the default prefacing with `<?xml...>`
-- More Robust Quoted Strings
-- lapp: improved detection of unsupported short flags
+  -  Add Python style url module for quote and unquote.
+  -  stringx.quote_string, which scans for embedded long-string quote matches and escapes them by creating a long-string quote.
+  -  issue #117: tablex.range now works with decreasing numbers, consistent with numerical for loop
+  -  utils.import will NOT override global symbols (import 'math' caused global type() to be clobbered)
+  - issue #125: DOCTYPE ignored in xml documents as well
+  - Allow XML tostring() function to customize the default prefacing with `<?xml...>`
+  - More Robust Quoted Strings
+  - lapp: improved detection of unsupported short flags
 
 ## 1.3.1 (2013-09-24)
 
@@ -366,64 +369,64 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
 
 ### Changes
 
-- class: RIP base method - not possible to implement correctly
-- lapp: short flags can now always be followed directly by their value, for instance,
+  - class: RIP base method - not possible to implement correctly
+  - lapp: short flags can now always be followed directly by their value, for instance,
 `-I/usr/include/lua/5.1`
-- Date: new explicit `Date.Interval` class; `toUTC/toLocal` return new object; `Date.__tostring`
+  - Date: new explicit `Date.Interval` class; `toUTC/toLocal` return new object; `Date.__tostring`
 always returns ISO 8601 times for exact serialization.  `+/-` explicit operators. Date objects
 are explicitly flagged as being UTC or not.
 
 ### Fixes
 
-- class: super method fixed.
-- Date: DST is now accounted for properly.
-- Date: weekday calculation borked.
+  - class: super method fixed.
+  - Date: DST is now accounted for properly.
+  - Date: weekday calculation borked.
 
 ### Features
 
-- All tests pass with no-5.1-compatible Lua 5.2; now always uses `utils.load` and
+  - All tests pass with no-5.1-compatible Lua 5.2; now always uses `utils.load` and
 `utils.unpack` is always available.
-- types: new module containing `utils.is_xxx` methods plus new `to_bool`.
-- class: can be passed methods in a table (see `test=klass.lua`). This is
+  - types: new module containing `utils.is_xxx` methods plus new `to_bool`.
+  - class: can be passed methods in a table (see `test=klass.lua`). This is
 particularly convenient for using from Moonscript.
-- general documentation improvements, e.g `class`
+  - general documentation improvements, e.g `class`
 
 ## 1.2.1 (2013-06-21)
 
 ### Changes
 
-- utils.set(get)fenv always defined (_not_ set as globals for 5.2 anymore!).
+  - utils.set(get)fenv always defined (_not_ set as globals for 5.2 anymore!).
     These are defined in new module pl.compat, but still available through utils.
-- class.Frodo now puts 'Frodo' in _current environment_
+  - class.Frodo now puts 'Frodo' in _current environment_
 
 ### Fixes
 
-- lapp.add_type was broken (Pete Kazmier)
-- class broke with classes that redefined __newindex
-- Set.isdisjoint was broken because of misspelling; default ctor Set() now works as expected
-- tablex.transform was broken; result now has same keys as original (CoolistheName007)
-- xml match not handling empty matches (royalbee)
-- pl.strict: assigning nil to global declares it, as God intended. (Pierre Chapuis)
-- tests all work with pl.strict
-- 5.2 compatible load now respects mode
-- tablex.difference thought that a value of `false` meant 'not present' (Andrew Starke)
+  - lapp.add_type was broken (Pete Kazmier)
+  - class broke with classes that redefined __newindex
+  - Set.isdisjoint was broken because of misspelling; default ctor Set() now works as expected
+  - tablex.transform was broken; result now has same keys as original (CoolistheName007)
+  - xml match not handling empty matches (royalbee)
+  - pl.strict: assigning nil to global declares it, as God intended. (Pierre Chapuis)
+  - tests all work with pl.strict
+  - 5.2 compatible load now respects mode
+  - tablex.difference thought that a value of `false` meant 'not present' (Andrew Starke)
 
 ### Features
 
-- tablex.sort(t) iterates over sorted keys, tablex.sortv(t) iterates over sorted values (Pete Kazmier)
-- tablex.readonly(t) creates a read-only proxy for a table (John Schember)
-- utils.is_empty(o) true if o==nil, o is an empty table, or o is an empty string (John Schember)
-- utils.executeex(cmd,bin) returns true if successful, return code, plus stdout and stderr output as strings. (tieske)
-- class method base for calling inherited methods (theypsilon)
-- class supports pre-constructor _create for making a custom self (used in pl.List)
-- xml HTML mode improvements - can parse non-trivial well-formed HTML documents.
+  - tablex.sort(t) iterates over sorted keys, tablex.sortv(t) iterates over sorted values (Pete Kazmier)
+  - tablex.readonly(t) creates a read-only proxy for a table (John Schember)
+  - utils.is_empty(o) true if o==nil, o is an empty table, or o is an empty string (John Schember)
+  - utils.executeex(cmd,bin) returns true if successful, return code, plus stdout and stderr output as strings. (tieske)
+  - class method base for calling inherited methods (theypsilon)
+  - class supports pre-constructor _create for making a custom self (used in pl.List)
+  - xml HTML mode improvements - can parse non-trivial well-formed HTML documents.
     xml.parsehtml is a parse function, no longer a flag
-- if a LOM document has ordered attributes, use these when stringifying
-- xml.tostring has yet another extra parm to force prefacing with `<?xml...>`
-- lapp boolean flags may have `true` default
-- lapp slack mode where 'short' flags can be multi-char
-- test.asserteq etc take extra arg, which is extra level where error must be reported at
-- path.currentdir,chdir,rmdir,mkdir and dir as alias to lfs are exported; no dependencies on luafilesystem outside pl.path, making it easier to plug in different implementations.
+  - if a LOM document has ordered attributes, use these when stringifying
+  - xml.tostring has yet another extra parm to force prefacing with `<?xml...>`
+  - lapp boolean flags may have `true` default
+  - lapp slack mode where 'short' flags can be multi-char
+  - test.asserteq etc take extra arg, which is extra level where error must be reported at
+  - path.currentdir,chdir,rmdir,mkdir and dir as alias to lfs are exported; no dependencies on luafilesystem outside pl.path, making it easier to plug in different implementations.
 
 ## 1.2.0 (2013-05-28)
 
@@ -465,6 +468,7 @@ particularly convenient for using from Moonscript.
 - text optional operator % overload broken for 'fmt % fun'; new tests
 - a few occurances of non-existent function utils.error removed
 
+
 ## 0.9.6 (2011-09-11)
 
 ### Lua 5.2 compatibility
@@ -491,25 +495,25 @@ particularly convenient for using from Moonscript.
 
 ### Lua 5.2 compatibility
 
-- defines Lua 5.2 beta compatible load()
-- defines table.pack()
+ - defines Lua 5.2 beta compatible load()
+ - defines table.pack()
 
 ### New functions
 
-- stringx.title(): translates "a dog's day" to "A Dog's Day"
-- path.normpath(): translates 'A//B','A/./B' and 'A/C/../B' to 'A/B'
-- utils.execute(): returns ok,return-code: compatible with 5.1 and 5.2
+ - stringx.title(): translates "a dog's day" to "A Dog's Day"
+ - path.normpath(): translates 'A//B','A/./B' and 'A/C/../B' to 'A/B'
+ - utils.execute(): returns ok,return-code: compatible with 5.1 and 5.2
 
 ### Fixes
 
-- pretty.write() _always_ returns a string, but will return also an error string
+ - pretty.write() _always_ returns a string, but will return also an error string
 if the argument is not a table. Non-integer indices between 1 and #t are no longer falsely considered part of the array
-- stringx.expandtabs() now works like the Python string method; it will expand each field up to the next tab stop
-- path.normcase() was broken, because of a misguided attempt to normalize the path.
-- UNC specific fix to path.abspath()
-- UNC paths recognized as absolute; dir.makedir() works here
-- utils.quit() varargs broken, e.g. utils.quit("answer was %d",42)
-- some stray globals caused trouble with 'strict'
+ - stringx.expandtabs() now works like the Python string method; it will expand each field up to the next tab stop
+ - path.normcase() was broken, because of a misguided attempt to normalize the path.
+ - UNC specific fix to path.abspath()
+ - UNC paths recognized as absolute; dir.makedir() works here
+ - utils.quit() varargs broken, e.g. utils.quit("answer was %d",42)
+ - some stray globals caused trouble with 'strict'
 
 ## 0.9.4 (2011-04-08)
 
@@ -525,7 +529,7 @@ if the argument is not a table. Non-integer indices between 1 and #t are no long
 
 ### What's new with 0.8b ?
 
-#### Features
+#### Features:
 
 pl.app provides useful stuff like simple command-line argument parsing and require_here(), which
 makes subsequent require() calls look in the local directory by preference.
@@ -544,7 +548,7 @@ utils.readfile,writefile now insist on being given filenames. This will cause le
 tablex.search() is new: will look recursively in an arbitrary table; can specify tables not to follow.
 tablex.move() will work with source and destination tables the same, with overlapping ranges.
 
-#### Bug Fixes
+#### Bug Fixes:
 
 dir.copyfile() now works fine without Alien on Windows
 
@@ -555,7 +559,7 @@ tablex.move() had a problem with source size
 
 ### What's New with 0.7.0b?
 
-#### Features
+#### Features:
 
 utils.is_type(v,tp) can say is_type(s,'string') and is_type(l,List).
 utils.is_callable(v) either a function, or has a `__call` metamethod.
@@ -591,7 +595,7 @@ and attempts to be paranoid about its contents.
 
 sip.match_at_start(). Convenience function for anchored SIP matches.
 
-#### Bug Fixes
+#### Bug Fixes:
 
 tablex.deepcompare() was confused by false boolean values, which
 it thought were synonymous with being nil.
@@ -644,3 +648,5 @@ config.lines() had a problem with continued lines.
 
 Some operators were missing in pl.operator; have renamed them to be
 consistent with the Lua metamethod names.
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,294 +7,293 @@ deprecation policy.
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
 ## 1.13.0 (unreleased)
- - fix: `compat.warn` raised write guard warning in OpenResty
-   [#414](https://github.com/lunarmodules/Penlight/pull/414)
- - feat: `utils.enum` now accepts hash tables, to enable better error handling
-   [#413](https://github.com/lunarmodules/Penlight/pull/413)
- - feat: `utils.kpairs` new iterator over all non-integer keys
-   [#413](https://github.com/lunarmodules/Penlight/pull/413)
 
+- fix: `compat.warn` raised write guard warning in OpenResty
+   [#414](https://github.com/lunarmodules/Penlight/pull/414)
+- feat: `utils.enum` now accepts hash tables, to enable better error handling
+   [#413](https://github.com/lunarmodules/Penlight/pull/413)
+- feat: `utils.kpairs` new iterator over all non-integer keys
+   [#413](https://github.com/lunarmodules/Penlight/pull/413)
+- fix: `lapp` provides the file name when using the default argument
+   [#427](https://github.com/lunarmodules/Penlight/pull/427)
 
 ## 1.12.0 (2022-Jan-10)
- - deprecate: module `pl.text` the contents have moved to `pl.stringx` (removal later)
+
+- deprecate: module `pl.text` the contents have moved to `pl.stringx` (removal later)
    [#407](https://github.com/lunarmodules/Penlight/pull/407)
- - deprecate: module `pl.xml`, please switch to a more specialized library (removal later)
+- deprecate: module `pl.xml`, please switch to a more specialized library (removal later)
    [#409](https://github.com/lunarmodules/Penlight/pull/409)
- - feat: `utils.npairs` added. An iterator with a range that honours the `n` field
+- feat: `utils.npairs` added. An iterator with a range that honours the `n` field
    [#387](https://github.com/lunarmodules/Penlight/pull/387)
- - fix: `xml.maptags` would hang if it encountered text-nodes
+- fix: `xml.maptags` would hang if it encountered text-nodes
    [#396](https://github.com/lunarmodules/Penlight/pull/396)
- - fix: `text.dedent` didn't handle declining indents nor empty lines
+- fix: `text.dedent` didn't handle declining indents nor empty lines
    [#402](https://github.com/lunarmodules/Penlight/pull/402)
- - fix: `dir.getfiles`, `dir.getdirectories`, and `dir.getallfiles` now have the
+- fix: `dir.getfiles`, `dir.getdirectories`, and `dir.getallfiles` now have the
    directory optional, as was already documented
    [#405](https://github.com/lunarmodules/Penlight/pull/405)
- - feat: `array2d.default_range` now also takes a spreadsheet range, which means
+- feat: `array2d.default_range` now also takes a spreadsheet range, which means
    also other functions now take a range. [#404](https://github.com/lunarmodules/Penlight/pull/404)
- - fix: `lapp` enums allow [patterns magic characters](https://www.lua.org/pil/20.2.html)
+- fix: `lapp` enums allow [patterns magic characters](https://www.lua.org/pil/20.2.html)
    [#393](https://github.com/lunarmodules/Penlight/pull/393)
- - fix: `text.wrap` and `text.fill` numerous fixes for handling whitespace,
+- fix: `text.wrap` and `text.fill` numerous fixes for handling whitespace,
    accented characters, honouring width, etc.
    [#400](https://github.com/lunarmodules/Penlight/pull/400)
- - feat: `text.wrap` and `text.fill` have a new parameter to forcefully break words
+- feat: `text.wrap` and `text.fill` have a new parameter to forcefully break words
    longer than the width given.
    [#400](https://github.com/lunarmodules/Penlight/pull/400)
- - fix: `stringx.expandtabs` could error out on Lua 5.3+
+- fix: `stringx.expandtabs` could error out on Lua 5.3+
    [#406](https://github.com/lunarmodules/Penlight/pull/406)
- - fix: `pl` the module would not properly forward the `newindex` metamethod
+- fix: `pl` the module would not properly forward the `newindex` metamethod
    on the global table.
    [#395](https://github.com/lunarmodules/Penlight/pull/395)
- - feat: `utils.enum` added to create enums and prevent magic strings
+- feat: `utils.enum` added to create enums and prevent magic strings
    [#408](https://github.com/lunarmodules/Penlight/pull/408)
- - change: `xml.new` added some sanity checks on input
+- change: `xml.new` added some sanity checks on input
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
- - added: `xml.xml_escape` and `xml.xml_unescape` functions (previously private)
+- added: `xml.xml_escape` and `xml.xml_unescape` functions (previously private)
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
- - feat: `xml.tostring` now also takes numeric indents (previously only strings)
+- feat: `xml.tostring` now also takes numeric indents (previously only strings)
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
- - fix: `xml.walk` now detects recursion (errors out)
+- fix: `xml.walk` now detects recursion (errors out)
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
- - fix: `xml.clone` now detects recursion (errors out)
+- fix: `xml.clone` now detects recursion (errors out)
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
- - fix: `xml.compare` now detects recursion (errors out)
+- fix: `xml.compare` now detects recursion (errors out)
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
- - fix: `xml.compare` text compares now work
+- fix: `xml.compare` text compares now work
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
- - fix: `xml.compare` attribute order compares now only compare if both inputs provide an order
+- fix: `xml.compare` attribute order compares now only compare if both inputs provide an order
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
- - fix: `xml.compare` child comparisons failing now report proper error
+- fix: `xml.compare` child comparisons failing now report proper error
    [#397](https://github.com/lunarmodules/Penlight/pull/397)
-
 
 ## 1.11.0 (2021-Aug-18)
 
- - fix: `stringx.strip` behaved badly with string lengths > 200
+- fix: `stringx.strip` behaved badly with string lengths > 200
    [#382](https://github.com/lunarmodules/Penlight/pull/382)
- - fix: `path.currentdir` now takes no arguments and calls `lfs.currentdir` without argument
+- fix: `path.currentdir` now takes no arguments and calls `lfs.currentdir` without argument
    [#383](https://github.com/lunarmodules/Penlight/pull/383)
- - feat: `utils.raise_deprecation` now has an option to NOT include a
+- feat: `utils.raise_deprecation` now has an option to NOT include a
    stack-trace [#385](https://github.com/lunarmodules/Penlight/pull/385)
-
 
 ## 1.10.0 (2021-Apr-27)
 
- - deprecate: `permute.iter`, renamed to `permute.order_iter` (removal later)
+- deprecate: `permute.iter`, renamed to `permute.order_iter` (removal later)
    [#360](https://github.com/lunarmodules/Penlight/pull/360)
- - deprecate: `permute.table`, renamed to `permute.order_table` (removal later)
+- deprecate: `permute.table`, renamed to `permute.order_table` (removal later)
    [#360](https://github.com/lunarmodules/Penlight/pull/360)
- - deprecate: `Date` module (removal later)
+- deprecate: `Date` module (removal later)
    [#367](https://github.com/lunarmodules/Penlight/pull/367)
- - feat: `permute.list_iter` to iterate over different sets of values
+- feat: `permute.list_iter` to iterate over different sets of values
    [#360](https://github.com/lunarmodules/Penlight/pull/360)
- - feat: `permute.list_table` generate table with different sets of values
+- feat: `permute.list_table` generate table with different sets of values
    [#360](https://github.com/lunarmodules/Penlight/pull/360)
- - feat: Lua 5.4 'warn' compatibility function
+- feat: Lua 5.4 'warn' compatibility function
    [#366](https://github.com/lunarmodules/Penlight/pull/366)
- - feat: deprecation functionality `utils.raise_deprecation`
+- feat: deprecation functionality `utils.raise_deprecation`
    [#361](https://github.com/lunarmodules/Penlight/pull/361)
- - feat: `utils.splitv` now takes same args as `split`
+- feat: `utils.splitv` now takes same args as `split`
    [#373](https://github.com/lunarmodules/Penlight/pull/373)
- - fix: `dir.rmtree` failed to remove symlinks to directories
+- fix: `dir.rmtree` failed to remove symlinks to directories
    [#365](https://github.com/lunarmodules/Penlight/pull/365)
- - fix: `pretty.write` could error out on failing metamethods (Lua 5.3+)
+- fix: `pretty.write` could error out on failing metamethods (Lua 5.3+)
    [#368](https://github.com/lunarmodules/Penlight/pull/368)
- - fix: `app.parse` now correctly parses values containing '=' or ':'
+- fix: `app.parse` now correctly parses values containing '=' or ':'
    [#373](https://github.com/lunarmodules/Penlight/pull/373)
- - fix: `dir.makepath` failed to create top-level directories
+- fix: `dir.makepath` failed to create top-level directories
    [#372](https://github.com/lunarmodules/Penlight/pull/372)
- - overhaul: `array2d` module was updated, got additional tests and several
+- overhaul: `array2d` module was updated, got additional tests and several
    documentation updates
    [#377](https://github.com/lunarmodules/Penlight/pull/377)
- - feat: `aray2d` now accepts negative indices
- - feat: `array2d.row` added to align with `column`
- - fix: bad error message in `array2d.map`
- - fix: `array2d.flatten` now ensures to deliver a 'square' result if `nil` is
+- feat: `aray2d` now accepts negative indices
+- feat: `array2d.row` added to align with `column`
+- fix: bad error message in `array2d.map`
+- fix: `array2d.flatten` now ensures to deliver a 'square' result if `nil` is
    encountered
- - feat: `array2d.transpose` added
- - feat: `array2d.swap_rows` and `array2d.swap_cols` now return the array
- - fix: `aray2d.range` correctly recognizes `R` column in spreadsheet format, was
+- feat: `array2d.transpose` added
+- feat: `array2d.swap_rows` and `array2d.swap_cols` now return the array
+- fix: `aray2d.range` correctly recognizes `R` column in spreadsheet format, was
    mistaken for `R1C1` format.
- - fix: `aray2d.range` correctly recognizes 2 char column in spreadsheet format
- - feat: `array2d.default_range` added (previously private)
- - feat: `array2d.set` if used with a function now passes `i,j` to the function
+- fix: `aray2d.range` correctly recognizes 2 char column in spreadsheet format
+- feat: `array2d.default_range` added (previously private)
+- feat: `array2d.set` if used with a function now passes `i,j` to the function
    in line with the `new` implementation.
- - fix: `array2d.iter` didn't properly iterate the indices
+- fix: `array2d.iter` didn't properly iterate the indices
    [#376](https://github.com/lunarmodules/Penlight/issues/376)
- - feat: `array2d.columns` now returns a second value; the column index
- - feat: `array2d.rows` added to be in line with `columns`
-
+- feat: `array2d.columns` now returns a second value; the column index
+- feat: `array2d.rows` added to be in line with `columns`
 
 ## 1.9.2 (2020-Sep-27)
 
- - fix: dir.walk [#350](https://github.com/lunarmodules/Penlight/pull/350)
-
+- fix: dir.walk [#350](https://github.com/lunarmodules/Penlight/pull/350)
 
 ## 1.9.1 (2020-Sep-24)
 
- - released to superseed the 1.9.0 version which was retagged in git after some
+- released to superseed the 1.9.0 version which was retagged in git after some
    distro's already had picked it up. This version is identical to 1.8.1.
 
 ## 1.8.1 (2020-Sep-24) (replacing a briefly released but broken 1.9.0 version)
 
 ## Fixes
 
-  - In `pl.class`, `_init` can now be inherited from grandparent (or older ancestor) classes. [#289](https://github.com/lunarmodules/Penlight/pull/289)
-  - Fixes `dir`, `lexer`, and `permute` to no longer use coroutines. [#344](https://github.com/lunarmodules/Penlight/pull/344)
+- In `pl.class`, `_init` can now be inherited from grandparent (or older ancestor) classes. [#289](https://github.com/lunarmodules/Penlight/pull/289)
+- Fixes `dir`, `lexer`, and `permute` to no longer use coroutines. [#344](https://github.com/lunarmodules/Penlight/pull/344)
 
 ## 1.8.0 (2020-Aug-05)
 
 ### New features
 
-  - `pretty.debug` quickly dumps a set of values to stdout for debug purposes
+- `pretty.debug` quickly dumps a set of values to stdout for debug purposes
 
 ### Changes
 
-  - `pretty.write`: now also sorts non-string keys [#319](https://github.com/lunarmodules/Penlight/pull/319)
-  - `stringx.count` has an extra option to allow overlapping matches
+- `pretty.write`: now also sorts non-string keys [#319](https://github.com/lunarmodules/Penlight/pull/319)
+- `stringx.count` has an extra option to allow overlapping matches
     [#326](https://github.com/lunarmodules/Penlight/pull/326)
-  - added an extra changelog entry for `types.is_empty` on the 1.6.0 changelog, due
+- added an extra changelog entry for `types.is_empty` on the 1.6.0 changelog, due
     to additional fixed behaviour not called out appropriately [#313](https://github.com/lunarmodules/Penlight/pull/313)
-  - `path.packagepath` now returns a proper error message with names tried if
+- `path.packagepath` now returns a proper error message with names tried if
     it fails
 
 ### Fixes
 
-  - Fix: `stringx.rfind` now properly works with overlapping matches
+- Fix: `stringx.rfind` now properly works with overlapping matches
     [#314](https://github.com/lunarmodules/Penlight/pull/314)
-  - Fix: `package.searchpath` (in module `pl.compat`)
+- Fix: `package.searchpath` (in module `pl.compat`)
     [#328](https://github.com/lunarmodules/Penlight/pull/328)
-  - Fix: `path.isabs` now reports drive + relative-path as `false`, eg. "c:some/path" (Windows only)
-  - Fix: OpenResty coroutines, used by `dir.dirtree`, `pl.lexer`, `pl.permute`. If
+- Fix: `path.isabs` now reports drive + relative-path as `false`, eg. "c:some/path" (Windows only)
+- Fix: OpenResty coroutines, used by `dir.dirtree`, `pl.lexer`, `pl.permute`. If
     available the original coroutine functions are now used [#329](https://github.com/lunarmodules/Penlight/pull/329)
-  - Fix: in `pl.strict` also predefine global `_PROMPT2`
-  - Fix: in `pl.strict` apply `tostring` to the given name, in case it is not a string.
-  - Fix: the lexer would not recognize numbers without leading zero; "-.123".
+- Fix: in `pl.strict` also predefine global `_PROMPT2`
+- Fix: in `pl.strict` apply `tostring` to the given name, in case it is not a string.
+- Fix: the lexer would not recognize numbers without leading zero; "-.123".
     See [#315](https://github.com/lunarmodules/Penlight/issues/315)
 
 ## 1.7.0 (2019-Oct-14)
 
 ### New features
 
-  - `utils.quote_arg` will now optionally take an array of arguments and escape
+- `utils.quote_arg` will now optionally take an array of arguments and escape
     them all into a single string.
-  - `app.parse_args` now accepts a 3rd parameter with a list of valid flags and aliasses
-  - `app.script_name` returns the name of the current script (previously a private function)
+- `app.parse_args` now accepts a 3rd parameter with a list of valid flags and aliasses
+- `app.script_name` returns the name of the current script (previously a private function)
 
 ### Changes
 
-  - Documentation updates
-  - `utils.quit`: exit message is no longer required, and closes the Lua state (on 5.2+).
-  - `utils.assert_arg` and `utils.assert_string`: now return the validated value
-  - `pl.compat`: now exports the `jit` and `jit52` flags
-  - `pretty.write`: now sorts the output for easier diffs [#293](https://github.com/lunarmodules/Penlight/pull/293)
+- Documentation updates
+- `utils.quit`: exit message is no longer required, and closes the Lua state (on 5.2+).
+- `utils.assert_arg` and `utils.assert_string`: now return the validated value
+- `pl.compat`: now exports the `jit` and `jit52` flags
+- `pretty.write`: now sorts the output for easier diffs [#293](https://github.com/lunarmodules/Penlight/pull/293)
 
 ### Fixes
 
-  - `utils.raise` changed the global `on_error`-level when passing in bad arguments
-  - `utils.writefile` now checks and returns errors when writing
-  - `compat.execute` now handles the Windows exitcode -1 properly
-  - `types.is_empty` would return true on spaces always, independent of the parameter
-  - `types.to_bool` will now compare case-insensitive for the extra passed strings
-  - `app.require_here` will now properly handle an absolute base path
-  - `stringx.split` will no longer append an empty match if the number of requested
+- `utils.raise` changed the global `on_error`-level when passing in bad arguments
+- `utils.writefile` now checks and returns errors when writing
+- `compat.execute` now handles the Windows exitcode -1 properly
+- `types.is_empty` would return true on spaces always, independent of the parameter
+- `types.to_bool` will now compare case-insensitive for the extra passed strings
+- `app.require_here` will now properly handle an absolute base path
+- `stringx.split` will no longer append an empty match if the number of requested
     elements has already been reached [#295](https://github.com/lunarmodules/Penlight/pull/295)
-  - `path.common_prefix` and `path.relpath` return the result in the original casing
+- `path.common_prefix` and `path.relpath` return the result in the original casing
     (only impacted Windows) [#297](https://github.com/lunarmodules/Penlight/pull/297)
-  - `dir.copyfile`, `dir.movefile`, and `dir.makepath` create the new file/path with
+- `dir.copyfile`, `dir.movefile`, and `dir.makepath` create the new file/path with
     the requested casing, and no longer force lowercase (only impacted Windows)
     [#297](https://github.com/lunarmodules/Penlight/pull/297)
-  - added a missing assertion on `path.getmtime` [#291](https://github.com/lunarmodules/Penlight/pull/291)
-  - `stringx.rpartition` returned bad results on a not-found [#299](https://github.com/lunarmodules/Penlight/pull/299)
+- added a missing assertion on `path.getmtime` [#291](https://github.com/lunarmodules/Penlight/pull/291)
+- `stringx.rpartition` returned bad results on a not-found [#299](https://github.com/lunarmodules/Penlight/pull/299)
 
 ## 1.6.0 (2018-Nov-23)
 
 ### New features
 
-  - `pl.compat` now provides `unpack` as `table.unpack` on Lua 5.1
+- `pl.compat` now provides `unpack` as `table.unpack` on Lua 5.1
 
 ### Changes
 
-  - `utils.unpack` is now documented and respects `.n` field of its argument.
-  - `tablex.deepcopy` and `tablex.deepcompare` are now cycle aware (#262)
-  - Installing through LuaRocks will now include the full rendered documentation
+- `utils.unpack` is now documented and respects `.n` field of its argument.
+- `tablex.deepcopy` and `tablex.deepcompare` are now cycle aware (#262)
+- Installing through LuaRocks will now include the full rendered documentation
 
 ### Fixes
 
-  - Fixed `seq.last` returning `nil` instead of an empty list when given an empty iterator (#253).
-  - `pl.template` now applies `tostring` when substituting values in templates, avoiding errors when they are not strings or numbers (#256).
-  - Fixed `pl.import_into` not importing some Penlight modules (#268).
-  - Fixed version number stuck at 1.5.2 (#260).
-  - Fixed `types.is_empty` returning `true` on tables containing `false` key (#267).
-  - Fixed `types.is_empty` returning `false` if not a nil/table/string
-  - Fixed `test.assertraise` throwing an error when passed an array with a function to call plus its arguments (#272).
-  - Fixed `test.assertraise` not throwing an error when given function does not error but instead returns a string matching given error pattern.
-  - Fixed placeholder expressions being evaluated with wrong precedence of binary and unary negation.
-  - Fixed placeholder expressions being evaluated assuming wrong binary operator associativity (e.g. `_1-(_2+_3)` was evaluated as `(_1-_2)+_3`.
-  - Fixed placeholder expressions being evaluated as if unary operators take precedence over power operator (e.g. `(-_1)^_2`) was evaluated as `-(_1^2)`).
-  - Fixed vulnerable backtracking pattern in `pl.stringx.strip` (#275)
+- Fixed `seq.last` returning `nil` instead of an empty list when given an empty iterator (#253).
+- `pl.template` now applies `tostring` when substituting values in templates, avoiding errors when they are not strings or numbers (#256).
+- Fixed `pl.import_into` not importing some Penlight modules (#268).
+- Fixed version number stuck at 1.5.2 (#260).
+- Fixed `types.is_empty` returning `true` on tables containing `false` key (#267).
+- Fixed `types.is_empty` returning `false` if not a nil/table/string
+- Fixed `test.assertraise` throwing an error when passed an array with a function to call plus its arguments (#272).
+- Fixed `test.assertraise` not throwing an error when given function does not error but instead returns a string matching given error pattern.
+- Fixed placeholder expressions being evaluated with wrong precedence of binary and unary negation.
+- Fixed placeholder expressions being evaluated assuming wrong binary operator associativity (e.g. `_1-(_2+_3)` was evaluated as `(_1-_2)+_3`.
+- Fixed placeholder expressions being evaluated as if unary operators take precedence over power operator (e.g. `(-_1)^_2`) was evaluated as `-(_1^2)`).
+- Fixed vulnerable backtracking pattern in `pl.stringx.strip` (#275)
 
 ## 1.5.4 (2017-07-17)
 
 ### Fixes
 
-  - Fixed `compat.execute` behaving differently on Lua 5.1 and 5.1+.
-  - Fixed `lapp.process_options_string` setting global `success` variable.
+- Fixed `compat.execute` behaving differently on Lua 5.1 and 5.1+.
+- Fixed `lapp.process_options_string` setting global `success` variable.
 
 ## 1.5.3 (2017-07-16)
 
 ### Changes
 
-  - Added `template.compile` function that allows caching compiled template and rendering it multiple times.
-  - Added special `_debug` field to environment table argument in `template.substitute` for printing generated template code upon render error.
+- Added `template.compile` function that allows caching compiled template and rendering it multiple times.
+- Added special `_debug` field to environment table argument in `template.substitute` for printing generated template code upon render error.
 
 ### Fixes
 
-  - Fixed error (`attempt to concatenate a nil value (local 'vtype')`) in `lapp.process_options_string`.
+- Fixed error (`attempt to concatenate a nil value (local 'vtype')`) in `lapp.process_options_string`.
 
 ## 1.5.2 (2017-04-08)
 
 ### Fixes
 
-  - Removed leftover debug pring in `lapp.process_options_string`.
+- Removed leftover debug pring in `lapp.process_options_string`.
 
 ## 1.5.1 (2017-04-02)
 
 ### Fixes
 
-  - Fixed `dir.getfiles` matching given pattern against full paths from base directory instead of file names.
+- Fixed `dir.getfiles` matching given pattern against full paths from base directory instead of file names.
 
 ## 1.5.0 (2017-04-01)
 
 ### Changes
 
-  - `stringx.splitlines` considers `\r\n` a single line ending.
-  - `stringx.splitlines` returns an empty list for an empty string.
+- `stringx.splitlines` considers `\r\n` a single line ending.
+- `stringx.splitlines` returns an empty list for an empty string.
 
 ### Fixes
 
-  - `tablex.count_map` no longer raises an error.
-  - `strict.module` correctly handles existing `__index` metamethod returning `false`.
-  - `app.parse_args` accepts colon as a separator between option name and value, as advertised.
-  - `pretty.load` handles case where a C hook is present.
+- `tablex.count_map` no longer raises an error.
+- `strict.module` correctly handles existing `__index` metamethod returning `false`.
+- `app.parse_args` accepts colon as a separator between option name and value, as advertised.
+- `pretty.load` handles case where a C hook is present.
   ' `os.execute` had issue with LuaJIT in 5.2 compat mode.
 
 ### Features
 
-  - `template` supports customizing inline escape character and chunk name.
-  - `seq` constructor supports iterators with a state object as the second argument.
-  - `stringx.splitlines` has `keep_ends` argument.
-  - `tablex.reduce` can take an optional initial value.
+- `template` supports customizing inline escape character and chunk name.
+- `seq` constructor supports iterators with a state object as the second argument.
+- `stringx.splitlines` has `keep_ends` argument.
+- `tablex.reduce` can take an optional initial value.
 
 ## 1.4.1 (2016-08-16)
 
 ### Changes
 
-  - All functions that return instances of `pl.List`, `pl.Map` and `pl.Set` now require corresponding modules,
+- All functions that return instances of `pl.List`, `pl.Map` and `pl.Set` now require corresponding modules,
    so that their methods always work right away.
 
 ### Fixes
 
-  - Fixed `dir.getallfiles` returning an empty array when called without `pattern` argument.
+- Fixed `dir.getallfiles` returning an empty array when called without `pattern` argument.
 
 ### Features
 
@@ -304,63 +303,62 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
 
 ### Fixes
 
-  - `pl.path` covers edge cases better (e.g `path.normpath` was broken)
-  - `p.dir` shell patterns fixed
-  - `os.tmpname` broken on modern Windows/MSVC14
-  - (likewise for `utils.executeex` which depends on it)
-  - `pretty.write` more robust and does not lose floating-point precision;
+- `pl.path` covers edge cases better (e.g `path.normpath` was broken)
+- `p.dir` shell patterns fixed
+- `os.tmpname` broken on modern Windows/MSVC14
+- (likewise for `utils.executeex` which depends on it)
+- `pretty.write` more robust and does not lose floating-point precision;
     saves and restores debug hooks when loading.
-  - `pl.lexer` fixes: `cpp` lexer now filters space by default
-  - `tablex.sortv` no longer assumes that the values are all unique
-  - `stringx.center` is now consistent with Python; `stringx.rfind` and
+- `pl.lexer` fixes: `cpp` lexer now filters space by default
+- `tablex.sortv` no longer assumes that the values are all unique
+- `stringx.center` is now consistent with Python; `stringx.rfind` and
   `string.quote_string` fixed.
-  - `data.write` had a problem with default delimiter, properly returns error now.
-  - `pl.Set` `+` and `-` now have correct semantics
+- `data.write` had a problem with default delimiter, properly returns error now.
+- `pl.Set` `+` and `-` now have correct semantics
 
 ### Features
 
-  - `pl.tablex` has `union` and `merge` convenience functions
-  - `pl.lapp` understands '--' meaning end of parsed arguments
-  - `utils.quote_arg` quotes command arguments for `os.execute`,
+- `pl.tablex` has `union` and `merge` convenience functions
+- `pl.lapp` understands '--' meaning end of parsed arguments
+- `utils.quote_arg` quotes command arguments for `os.execute`,
   correctly handling all special characters.
-  - `utils.writefile` has optional `is_bin` argument
-  - 'pl.lexer' supports line numbers with string argument
-  - `stringx.endswith` may be passed an array of possible suffixes.
-  - `data.read` - in CSV mode, assume empty fields are numerical zero
-
+- `utils.writefile` has optional `is_bin` argument
+- 'pl.lexer' supports line numbers with string argument
+- `stringx.endswith` may be passed an array of possible suffixes.
+- `data.read` - in CSV mode, assume empty fields are numerical zero
 
 ## 1.3.2 (2015-05-10)
 
 ### Changes
 
-  - now works and passes tests with Lua 5.3
-  - utils.import will NOT override global symbols (import 'math' caused global type() to be clobbered)
-  - Updated pl.dir.file_op to return true on success and false on failure...
-  - workaround for issues with pl.lapp with amalg.lua - will look at global LAPP_SCRIPT if arg[0] is nil
+- now works and passes tests with Lua 5.3
+- utils.import will NOT override global symbols (import 'math' caused global type() to be clobbered)
+- Updated pl.dir.file_op to return true on success and false on failure...
+- workaround for issues with pl.lapp with amalg.lua - will look at global LAPP_SCRIPT if arg[0] is nil
 
 ### Fixes
 
-  - func was broken: do NOT use ipairs to iterate if __index is overriden!
-  - issue #133 pretty.read (naively) confused by unbalanced brackets
-  - xml attribute underscore fix for simple parser
-  - Fix path.normpath
-  - lexer: fix parsing block comments/string. fix hang on empty string.
-  -  Fixed utils.execute returning different values for Lua 5.1 and Lua 5.2
-  - Issue #97; fixed attempt to put a month into a day
-  -  problem with tablex.count_map with custom comparison
-  - tablex.pairmap overwrites result if key already exists; instead, upon detection that key already exists
-	for a returned value, we modify the key's value to be a table and insert values into that table
+- func was broken: do NOT use ipairs to iterate if __index is overriden!
+- issue #133 pretty.read (naively) confused by unbalanced brackets
+- xml attribute underscore fix for simple parser
+- Fix path.normpath
+- lexer: fix parsing block comments/string. fix hang on empty string.
+- Fixed utils.execute returning different values for Lua 5.1 and Lua 5.2
+- Issue #97; fixed attempt to put a month into a day
+- problem with tablex.count_map with custom comparison
+- tablex.pairmap overwrites result if key already exists; instead, upon detection that key already exists
+ for a returned value, we modify the key's value to be a table and insert values into that table
 
 ### Features
 
-  -  Add Python style url module for quote and unquote.
-  -  stringx.quote_string, which scans for embedded long-string quote matches and escapes them by creating a long-string quote.
-  -  issue #117: tablex.range now works with decreasing numbers, consistent with numerical for loop
-  -  utils.import will NOT override global symbols (import 'math' caused global type() to be clobbered)
-  - issue #125: DOCTYPE ignored in xml documents as well
-  - Allow XML tostring() function to customize the default prefacing with `<?xml...>`
-  - More Robust Quoted Strings
-  - lapp: improved detection of unsupported short flags
+- Add Python style url module for quote and unquote.
+- stringx.quote_string, which scans for embedded long-string quote matches and escapes them by creating a long-string quote.
+- issue #117: tablex.range now works with decreasing numbers, consistent with numerical for loop
+- utils.import will NOT override global symbols (import 'math' caused global type() to be clobbered)
+- issue #125: DOCTYPE ignored in xml documents as well
+- Allow XML tostring() function to customize the default prefacing with `<?xml...>`
+- More Robust Quoted Strings
+- lapp: improved detection of unsupported short flags
 
 ## 1.3.1 (2013-09-24)
 
@@ -368,64 +366,64 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
 
 ### Changes
 
-  - class: RIP base method - not possible to implement correctly
-  - lapp: short flags can now always be followed directly by their value, for instance,
+- class: RIP base method - not possible to implement correctly
+- lapp: short flags can now always be followed directly by their value, for instance,
 `-I/usr/include/lua/5.1`
-  - Date: new explicit `Date.Interval` class; `toUTC/toLocal` return new object; `Date.__tostring`
+- Date: new explicit `Date.Interval` class; `toUTC/toLocal` return new object; `Date.__tostring`
 always returns ISO 8601 times for exact serialization.  `+/-` explicit operators. Date objects
 are explicitly flagged as being UTC or not.
 
 ### Fixes
 
-  - class: super method fixed.
-  - Date: DST is now accounted for properly.
-  - Date: weekday calculation borked.
+- class: super method fixed.
+- Date: DST is now accounted for properly.
+- Date: weekday calculation borked.
 
 ### Features
 
-  - All tests pass with no-5.1-compatible Lua 5.2; now always uses `utils.load` and
+- All tests pass with no-5.1-compatible Lua 5.2; now always uses `utils.load` and
 `utils.unpack` is always available.
-  - types: new module containing `utils.is_xxx` methods plus new `to_bool`.
-  - class: can be passed methods in a table (see `test=klass.lua`). This is
+- types: new module containing `utils.is_xxx` methods plus new `to_bool`.
+- class: can be passed methods in a table (see `test=klass.lua`). This is
 particularly convenient for using from Moonscript.
-  - general documentation improvements, e.g `class`
+- general documentation improvements, e.g `class`
 
 ## 1.2.1 (2013-06-21)
 
 ### Changes
 
-  - utils.set(get)fenv always defined (_not_ set as globals for 5.2 anymore!).
+- utils.set(get)fenv always defined (_not_ set as globals for 5.2 anymore!).
     These are defined in new module pl.compat, but still available through utils.
-  - class.Frodo now puts 'Frodo' in _current environment_
+- class.Frodo now puts 'Frodo' in _current environment_
 
 ### Fixes
 
-  - lapp.add_type was broken (Pete Kazmier)
-  - class broke with classes that redefined __newindex
-  - Set.isdisjoint was broken because of misspelling; default ctor Set() now works as expected
-  - tablex.transform was broken; result now has same keys as original (CoolistheName007)
-  - xml match not handling empty matches (royalbee)
-  - pl.strict: assigning nil to global declares it, as God intended. (Pierre Chapuis)
-  - tests all work with pl.strict
-  - 5.2 compatible load now respects mode
-  - tablex.difference thought that a value of `false` meant 'not present' (Andrew Starke)
+- lapp.add_type was broken (Pete Kazmier)
+- class broke with classes that redefined __newindex
+- Set.isdisjoint was broken because of misspelling; default ctor Set() now works as expected
+- tablex.transform was broken; result now has same keys as original (CoolistheName007)
+- xml match not handling empty matches (royalbee)
+- pl.strict: assigning nil to global declares it, as God intended. (Pierre Chapuis)
+- tests all work with pl.strict
+- 5.2 compatible load now respects mode
+- tablex.difference thought that a value of `false` meant 'not present' (Andrew Starke)
 
 ### Features
 
-  - tablex.sort(t) iterates over sorted keys, tablex.sortv(t) iterates over sorted values (Pete Kazmier)
-  - tablex.readonly(t) creates a read-only proxy for a table (John Schember)
-  - utils.is_empty(o) true if o==nil, o is an empty table, or o is an empty string (John Schember)
-  - utils.executeex(cmd,bin) returns true if successful, return code, plus stdout and stderr output as strings. (tieske)
-  - class method base for calling inherited methods (theypsilon)
-  - class supports pre-constructor _create for making a custom self (used in pl.List)
-  - xml HTML mode improvements - can parse non-trivial well-formed HTML documents.
+- tablex.sort(t) iterates over sorted keys, tablex.sortv(t) iterates over sorted values (Pete Kazmier)
+- tablex.readonly(t) creates a read-only proxy for a table (John Schember)
+- utils.is_empty(o) true if o==nil, o is an empty table, or o is an empty string (John Schember)
+- utils.executeex(cmd,bin) returns true if successful, return code, plus stdout and stderr output as strings. (tieske)
+- class method base for calling inherited methods (theypsilon)
+- class supports pre-constructor _create for making a custom self (used in pl.List)
+- xml HTML mode improvements - can parse non-trivial well-formed HTML documents.
     xml.parsehtml is a parse function, no longer a flag
-  - if a LOM document has ordered attributes, use these when stringifying
-  - xml.tostring has yet another extra parm to force prefacing with `<?xml...>`
-  - lapp boolean flags may have `true` default
-  - lapp slack mode where 'short' flags can be multi-char
-  - test.asserteq etc take extra arg, which is extra level where error must be reported at
-  - path.currentdir,chdir,rmdir,mkdir and dir as alias to lfs are exported; no dependencies on luafilesystem outside pl.path, making it easier to plug in different implementations.
+- if a LOM document has ordered attributes, use these when stringifying
+- xml.tostring has yet another extra parm to force prefacing with `<?xml...>`
+- lapp boolean flags may have `true` default
+- lapp slack mode where 'short' flags can be multi-char
+- test.asserteq etc take extra arg, which is extra level where error must be reported at
+- path.currentdir,chdir,rmdir,mkdir and dir as alias to lfs are exported; no dependencies on luafilesystem outside pl.path, making it easier to plug in different implementations.
 
 ## 1.2.0 (2013-05-28)
 
@@ -467,7 +465,6 @@ particularly convenient for using from Moonscript.
 - text optional operator % overload broken for 'fmt % fun'; new tests
 - a few occurances of non-existent function utils.error removed
 
-
 ## 0.9.6 (2011-09-11)
 
 ### Lua 5.2 compatibility
@@ -494,25 +491,25 @@ particularly convenient for using from Moonscript.
 
 ### Lua 5.2 compatibility
 
- - defines Lua 5.2 beta compatible load()
- - defines table.pack()
+- defines Lua 5.2 beta compatible load()
+- defines table.pack()
 
 ### New functions
 
- - stringx.title(): translates "a dog's day" to "A Dog's Day"
- - path.normpath(): translates 'A//B','A/./B' and 'A/C/../B' to 'A/B'
- - utils.execute(): returns ok,return-code: compatible with 5.1 and 5.2
+- stringx.title(): translates "a dog's day" to "A Dog's Day"
+- path.normpath(): translates 'A//B','A/./B' and 'A/C/../B' to 'A/B'
+- utils.execute(): returns ok,return-code: compatible with 5.1 and 5.2
 
 ### Fixes
 
- - pretty.write() _always_ returns a string, but will return also an error string
+- pretty.write() _always_ returns a string, but will return also an error string
 if the argument is not a table. Non-integer indices between 1 and #t are no longer falsely considered part of the array
- - stringx.expandtabs() now works like the Python string method; it will expand each field up to the next tab stop
- - path.normcase() was broken, because of a misguided attempt to normalize the path.
- - UNC specific fix to path.abspath()
- - UNC paths recognized as absolute; dir.makedir() works here
- - utils.quit() varargs broken, e.g. utils.quit("answer was %d",42)
- - some stray globals caused trouble with 'strict'
+- stringx.expandtabs() now works like the Python string method; it will expand each field up to the next tab stop
+- path.normcase() was broken, because of a misguided attempt to normalize the path.
+- UNC specific fix to path.abspath()
+- UNC paths recognized as absolute; dir.makedir() works here
+- utils.quit() varargs broken, e.g. utils.quit("answer was %d",42)
+- some stray globals caused trouble with 'strict'
 
 ## 0.9.4 (2011-04-08)
 
@@ -528,7 +525,7 @@ if the argument is not a table. Non-integer indices between 1 and #t are no long
 
 ### What's new with 0.8b ?
 
-#### Features:
+#### Features
 
 pl.app provides useful stuff like simple command-line argument parsing and require_here(), which
 makes subsequent require() calls look in the local directory by preference.
@@ -547,7 +544,7 @@ utils.readfile,writefile now insist on being given filenames. This will cause le
 tablex.search() is new: will look recursively in an arbitrary table; can specify tables not to follow.
 tablex.move() will work with source and destination tables the same, with overlapping ranges.
 
-#### Bug Fixes:
+#### Bug Fixes
 
 dir.copyfile() now works fine without Alien on Windows
 
@@ -558,7 +555,7 @@ tablex.move() had a problem with source size
 
 ### What's New with 0.7.0b?
 
-#### Features:
+#### Features
 
 utils.is_type(v,tp) can say is_type(s,'string') and is_type(l,List).
 utils.is_callable(v) either a function, or has a `__call` metamethod.
@@ -594,7 +591,7 @@ and attempts to be paranoid about its contents.
 
 sip.match_at_start(). Convenience function for anchored SIP matches.
 
-#### Bug Fixes:
+#### Bug Fixes
 
 tablex.deepcompare() was confused by false boolean values, which
 it thought were synonymous with being nil.
@@ -647,5 +644,3 @@ config.lines() had a problem with continued lines.
 
 Some operators were missing in pl.operator; have renamed them to be
 consistent with the Lua metamethod names.
-
-

--- a/lua/pl/lapp.lua
+++ b/lua/pl/lapp.lua
@@ -246,6 +246,7 @@ function lapp.process_options_string(str,args)
             line = res.rest
             res = {}
             local optional
+            local defval_str
             -- do we have ([optional] [<type>] [default <val>])?
             if match('$({def} $',line,res) or match('$({def}',line,res) then
                 local typespec = strip(res.def)
@@ -288,6 +289,7 @@ function lapp.process_options_string(str,args)
                 -- optional 'default value' clause. Type is inferred as
                 -- 'string' or 'number' if there's no explicit type
                 if default or match('default $r{rest}',typespec,res) then
+                    defval_str = res.rest
                     defval,vtype = process_default(res.rest,vtype)
                 end
             else -- must be a plain flag, no extra parameter required
@@ -297,6 +299,7 @@ function lapp.process_options_string(str,args)
             local ps = {
                 type = vtype,
                 defval = defval,
+                defval_str = defval_str,
                 required = defval == nil and not optional,
                 comment = res.rest or optparm,
                 constraint = constraint,
@@ -426,6 +429,9 @@ function lapp.process_options_string(str,args)
         if not ps.used then
             if ps.required then lapp.error("missing required parameter: "..parm) end
             set_result(ps,parm,ps.defval)
+            if builtin_types[ps.type] == "file" then
+                set_result(ps, parm .. "_name", ps.defval_str)
+            end
         end
     end
     return results

--- a/tests/test-lapp.lua
+++ b/tests/test-lapp.lua
@@ -47,16 +47,16 @@ Various flags and option types
 
 check(simple,
     {'-o','in'},
-    {quiet=false,p=false,o='in',input='<file>'})
+    {quiet=false,p=false,o='in',input='<file>', input_name="stdin"})
 
 ---- value of flag may be separated by '=' or ':'
 check(simple,
     {'-o=in'},
-    {quiet=false,p=false,o='in',input='<file>'})
+    {quiet=false,p=false,o='in',input='<file>', input_name="stdin"})
 
 check(simple,
     {'-o:in'},
-    {quiet=false,p=false,o='in',input='<file>'})
+    {quiet=false,p=false,o='in',input='<file>', input_name="stdin"})
 
 -- Check lapp.callback.
 local calls = {}
@@ -155,6 +155,13 @@ check (false_flag,{'-g','-f'},{f=false,g=true})
 -- '--' indicates end of parameter parsing
 check (false_flag,{'-g','--'},{f=true,g=true})
 check (false_flag,{'-g','--','-a','frodo'},{f=true,g=true; '-a','frodo'})
+
+
+local default_file_flag = [[
+    -f (file-out default stdout)
+]]
+
+check (default_file_flag,{},{f="<file>", f_name = "stdout"})
 
 local addtype = [[
   -l (intlist) List of items


### PR DESCRIPTION
Currently if the default value is used for a filename, the arg table will not be populated with `*_name`. Added a fix for this scenario.


## Example

The below snippet would currently not pass `f_name` in the arg table
```lua
lapp.process_options_string([[

-f    (file-out default test.txt)
]], {})
```

