### PR TITLE
lapp support positional args with numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    [#413](https://github.com/lunarmodules/Penlight/pull/413)
  - fix: `lapp` provides the file name when using the default argument
    [#427](https://github.com/lunarmodules/Penlight/pull/427)
+ - fix: `lapp` positional arguments now allow digits after the first character
+   [#428](https://github.com/lunarmodules/Penlight/pull/428)
+
 
 ## 1.12.0 (2022-Jan-10)
  - deprecate: module `pl.text` the contents have moved to `pl.stringx` (removal later)

--- a/lua/pl/lapp.lua
+++ b/lua/pl/lapp.lua
@@ -237,7 +237,8 @@ function lapp.process_options_string(str,args)
         elseif check '$<{name} $'  then -- is it <parameter_name>?
             -- so <input file...> becomes input_file ...
             optparm,rest = res.name:match '([^%.]+)(.*)'
-            optparm = optparm:gsub('%A','_')
+            -- follow lua legal variable names
+            optparm = optparm:sub(1,1):gsub('%A','_') .. optparm:sub(2):gsub('%W', '_')
             varargs = rest == '...'
             append(parmlist,optparm)
         end

--- a/tests/test-lapp.lua
+++ b/tests/test-lapp.lua
@@ -157,11 +157,21 @@ check (false_flag,{'-g','--'},{f=true,g=true})
 check (false_flag,{'-g','--','-a','frodo'},{f=true,g=true; '-a','frodo'})
 
 
+
 local default_file_flag = [[
     -f (file-out default stdout)
 ]]
-
 check (default_file_flag,{},{f="<file>", f_name = "stdout"})
+
+
+
+local numbered_pos_args = [[
+    <arg1>     (string)
+    <arg2>     (string)
+    <3arg3>    (string)
+]]
+check (numbered_pos_args,{"1", "2", "3"},{arg1="1", arg2 = "2", _arg3 = "3"})
+
 
 local addtype = [[
   -l (intlist) List of items


### PR DESCRIPTION
Fix for #248. For now it follows lua variable name definition where the first letter cannot be a number. 