### PR TITLE
fix(pretty) error in pl.pretty table sort function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    [#431](https://github.com/lunarmodules/Penlight/pull/431)
  - feat: `app.require_here` now follows symlink'd main modules to their directory
    [#423](https://github.com/lunarmodules/Penlight/pull/423)
- - fix: `pretty.writeit` invalid order function for sorting
+ - fix: `pretty.write` invalid order function for sorting
    [#430](https://github.com/lunarmodules/Penlight/pull/430)
  - fix: `compat.warn` raised write guard warning in OpenResty
    [#414](https://github.com/lunarmodules/Penlight/pull/414)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    [#431](https://github.com/lunarmodules/Penlight/pull/431)
  - feat: `app.require_here` now follows symlink'd main modules to their directory
    [#423](https://github.com/lunarmodules/Penlight/pull/423)
+ - fix: `pretty.writeit` invalid order function for sorting
+   [#430](https://github.com/lunarmodules/Penlight/pull/430)
  - fix: `compat.warn` raised write guard warning in OpenResty
    [#414](https://github.com/lunarmodules/Penlight/pull/414)
  - feat: `utils.enum` now accepts hash tables, to enable better error handling

--- a/lua/pl/pretty.lua
+++ b/lua/pl/pretty.lua
@@ -284,10 +284,11 @@ function pretty.write (tbl,space,not_clever)
                end
             end
             table.sort(ordered_keys, function (a, b)
-                if type(a) == type(b)  and type(a) == 'string' then
-                    return a < b
+                if type(a) == type(b) then
+                    return tostring(a) < tostring(b)
+                else
+                    return type(a) < type(b)
                 end
-                return type(a) == 'boolean' or (type(b) ~= 'boolean' and type(a) == 'table')
             end)
             local function write_entry (key, val)
                 local tkey = type(key)

--- a/tests/test-pretty.lua
+++ b/tests/test-pretty.lua
@@ -86,8 +86,8 @@ asserteq( pretty.write(t1,""), [[{{},{}}]] )
 
 -- Check that write correctly print table with non number or string as keys
 
-t1 = { [true] = "boolean", a = "a", b = "b", [1] = 1, [0] = 0 }
-asserteq( pretty.write(t1,""), [[{1,["true"]="boolean",a="a",b="b",[0]=0}]] )
+t1 = { [true] = "boolean", [false] = "untrue", a = "a", b = "b", [1] = 1, [0] = 0 }
+asserteq( pretty.write(t1,""), [[{1,["false"]="untrue",["true"]="boolean",a="a",b="b",[0]=0}]] )
 
 
 -- Check number formatting


### PR DESCRIPTION
Function defined when sorting table is not deterministic and makes luajit
crash with error:
prefix/share/lua/5.1/pl/pretty.lua:286: invalid order function for sorting

This patch will fix the problem #429 