### PR TITLE
fix(xml) fix xml.parse() with filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ deprecation policy.
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
 ## 1.13.0 (unreleased)
+ - fix: `xml.parse` returned nonsense when given a file name
+   [#431](https://github.com/lunarmodules/Penlight/pull/431)
  - fix: `compat.warn` raised write guard warning in OpenResty
    [#414](https://github.com/lunarmodules/Penlight/pull/414)
  - feat: `utils.enum` now accepts hash tables, to enable better error handling

--- a/lua/pl/xml.lua
+++ b/lua/pl/xml.lua
@@ -114,10 +114,11 @@ function _M.parse(text_or_filename, is_file, use_basic)
   end
 
   if is_file then
-    local text_or_filename, err = utils.readfile(text_or_filename)
-    if not text_or_filename then
+    local text, err = utils.readfile(text_or_filename)
+    if not text then
       return nil, err
     end
+    text_or_filename = text
   end
 
   local doc, err = parser(text_or_filename)

--- a/tests/test-xml.lua
+++ b/tests/test-xml.lua
@@ -1,6 +1,8 @@
 local xml = require 'pl.xml'
 local asserteq = require 'pl.test'.asserteq
 local dump = require 'pl.pretty'.dump
+local path = require 'pl.path'
+local utils = require 'pl.utils'
 
 -- Prosody stanza.lua style XML building
 
@@ -532,5 +534,19 @@ print(xml.tostring(doc))
 
 asserteq(xml.tostring(doc),[[
 <hello><tag my_attribute='my_value'>dolly</tag></hello>]])
+
+
+-- parsing by file name
+
+local filename = path.tmpname()
+utils.writefile(filename, '<hello><world/></hello>')
+doc = xml.parse(filename, true, true)
+os.remove(filename)
+asserteq(type(doc), 'table')
+asserteq(xml.tostring(doc, '', '  ', nil, true), [[
+<?xml version='1.0'?>
+<hello>
+  <world/>
+</hello>]])
 
 


### PR DESCRIPTION
Penlight 1.12.0 has a bug where giving a file name to `xml.parse()` (with second argument `true`) will return nonsense (the file name again). It was broken in b749d88 due to a mistake in local variable scoping.

The attached commits add a test and fix the bug.