### PR TITLE
fix(utils) nil values in choose(cond, val1, val2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ deprecation policy.
 
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
+## 1.13.1 (2022-Dec-23)
+ - fix(utils) nil values in choose(cond, val1, val2)
+   [#447](https://github.com/lunarmodules/Penlight/pull/#447)
+
+## 1.13.1 (2022-Jul-22)
+ - fix: `warn` unquoted argument
+   [#439](https://github.com/lunarmodules/Penlight/pull/439)
+
 ## 1.13.1 (2022-Jul-22)
  - fix: `warn` unquoted argument
    [#439](https://github.com/lunarmodules/Penlight/pull/439)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,9 @@ deprecation policy.
 
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
-## 1.13.2 (2022-Dec-23)
- - fix(utils) nil values in choose(cond, val1, val2)
+## 1.13.x (unreleased)
+ - fix(utils) `nil` values in `utils.choose(cond, val1, val2)`
    [#447](https://github.com/lunarmodules/Penlight/pull/#447)
-
-## 1.13.1 (2022-Jul-22)
- - fix: `warn` unquoted argument
-   [#439](https://github.com/lunarmodules/Penlight/pull/439)
 
 ## 1.13.1 (2022-Jul-22)
  - fix: `warn` unquoted argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ deprecation policy.
 
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
-## 1.13.1 (2022-Dec-23)
+## 1.13.2 (2022-Dec-23)
  - fix(utils) nil values in choose(cond, val1, val2)
    [#447](https://github.com/lunarmodules/Penlight/pull/#447)
 

--- a/lua/pl/utils.lua
+++ b/lua/pl/utils.lua
@@ -141,7 +141,11 @@ end
 -- @param value1 Value returned if cond is truthy
 -- @param value2 Value returned if cond is falsy
 function utils.choose(cond, value1, value2)
-    return cond and value1 or value2
+    if cond then
+        return value1
+    else
+        return value2
+    end
 end
 
 --- convert an array of values to strings.

--- a/spec/utils-choose_spec.lua
+++ b/spec/utils-choose_spec.lua
@@ -1,4 +1,4 @@
-local utils = dofile("lua/pl/utils.lua")
+local utils = require("pl.utils")
 
 describe("pl.utils", function()
 

--- a/spec/utils-choose_spec.lua
+++ b/spec/utils-choose_spec.lua
@@ -1,0 +1,21 @@
+local utils = dofile("lua/pl/utils.lua")
+
+describe("pl.utils", function()
+
+  describe("choose", function ()
+
+    it("handles normal values", function()
+      assert.equal(utils.choose(true, 1, 2), 1)
+      assert.equal(utils.choose(false, 1, 2), 2)
+    end)
+
+    it("handles nils", function()
+      assert.equal(utils.choose(true, nil, 2), nil)
+      assert.equal(utils.choose(false, nil, 2), 2)
+      assert.equal(utils.choose(true, 1, nil), 1)
+      assert.equal(utils.choose(false, 1, nil), nil)
+    end)
+
+  end)
+
+end)

--- a/tests/test-utils.lua
+++ b/tests/test-utils.lua
@@ -83,6 +83,10 @@ asserteq(escape '$(bonzo)','%$%(bonzo%)')
 --- choose
 asserteq(utils.choose(true, 1, 2), 1)
 asserteq(utils.choose(false, 1, 2), 2)
+asserteq(utils.choose(true, nil, 2), nil)
+asserteq(utils.choose(false, nil, 2), 2)
+asserteq(utils.choose(true, 1, nil), 1)
+asserteq(utils.choose(false, 1, nil), nil)
 
 --- splitting strings ---
 local split = utils.split

--- a/tests/test-utils.lua
+++ b/tests/test-utils.lua
@@ -83,10 +83,6 @@ asserteq(escape '$(bonzo)','%$%(bonzo%)')
 --- choose
 asserteq(utils.choose(true, 1, 2), 1)
 asserteq(utils.choose(false, 1, 2), 2)
-asserteq(utils.choose(true, nil, 2), nil)
-asserteq(utils.choose(false, nil, 2), 2)
-asserteq(utils.choose(true, 1, nil), 1)
-asserteq(utils.choose(false, 1, nil), nil)
 
 --- splitting strings ---
 local split = utils.split


### PR DESCRIPTION
The original implementation of choose would fail if val1 was falsy. I have fixed this by replacing the "and/or" ternary logic with an if statement.

Example of failure:

  choose(true, nil, "hello") -- returns "hello"
  choose(true, false, "hello") -- returns "hello"

Internally, the evaluated expressions were as follows:

  true and nil or "hello"  -- returns "hello"
  true and false or "hello" -- returns "hello"

This commit updates the logic to be as follows:

  if true then return nil else return "hello" end  -- returns nil
  if true then return false else return "hello" end -- returns false