### PR TITLE
enhance(func) Extend compose to suport N functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ deprecation policy.
 
 see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) for release instructions
 
+## 1.14.0 (2022-Dec-24)
+ - enhance(func): extend compose to support N functions
+ - [#448](https://github.com/lunarmodules/Penlight/pull/448)
+
 ## 1.13.1 (2022-Jul-22)
  - fix: `warn` unquoted argument
    [#439](https://github.com/lunarmodules/Penlight/pull/439)

--- a/lua/pl/func.lua
+++ b/lua/pl/func.lua
@@ -337,22 +337,14 @@ func.bind1 = utils.bind1
 func.curry = func.bind1
 
 --- create a function which chains multiple functions.
--- a table of multiple functions can also be
--- passed instead of providing functions as
--- individual parameters.
 -- @func f a function of at least one argument
 -- @func g a function of at least one argument
 -- @param ... additional functions to compose
 -- @return a function
 -- @usage printf = compose(io.write, string.format)
--- @usage printf = compose({ io.write, string.format })
 -- @usage printf = compose(io.write, string.lower, string.format)
--- @usage printf = compose({ io.write, string.lower, string.format })
 function func.compose (...)
     local args = pack(...)
-    if type(args[1]) == "table" then
-      args = args[1]
-    end
     return tablex.reduce(function(f, g)
       return function(...)
         return f(g(...))

--- a/lua/pl/func.lua
+++ b/lua/pl/func.lua
@@ -336,13 +336,28 @@ utils.add_function_factory(_PEMT,func.I)
 func.bind1 = utils.bind1
 func.curry = func.bind1
 
---- create a function which chains two functions.
+--- create a function which chains multiple functions.
+-- a table of multiple functions can also be
+-- passed instead of providing functions as
+-- individual parameters.
 -- @func f a function of at least one argument
 -- @func g a function of at least one argument
+-- @param ... additional functions to compose
 -- @return a function
--- @usage printf = compose(io.write,string.format)
-function func.compose (f,g)
-    return function(...) return f(g(...)) end
+-- @usage printf = compose(io.write, string.format)
+-- @usage printf = compose({ io.write, string.format })
+-- @usage printf = compose(io.write, string.lower, string.format)
+-- @usage printf = compose({ io.write, string.lower, string.format })
+function func.compose (...)
+    local args = pack(...)
+    if type(args[1]) == "table" then
+      args = args[1]
+    end
+    return tablex.reduce(function(f, g)
+      return function(...)
+        return f(g(...))
+      end
+    end, args)
 end
 
 --- bind the arguments of a function to given values.

--- a/spec/func_spec.lua
+++ b/spec/func_spec.lua
@@ -1,0 +1,54 @@
+local func = require("pl.func")
+
+describe("pl.func", function ()
+
+  describe("compose", function ()
+
+    it("compose(f)(x) == f(x)", function ()
+      local f = function(x) return x + 1 end
+      assert.equals(func.compose(f)(1), f(1))
+    end)
+
+    it("compose(f, g)(x) == f(g(x))", function ()
+      local f = function(x) return x + 1 end
+      local g = function(x) return x + 2 end
+      assert.equals(func.compose(f, g)(1), f(g(1)))
+    end)
+
+    it("compose(f, g, h)(x) == f(g(h(x)))", function ()
+      local f = function(x) return x + 1 end
+      local g = function(x) return x + 2 end
+      local h = function(x) return x + 3 end
+      assert.equals(func.compose(f, g, h)(1), f(g(h(1))))
+    end)
+
+    it("compose(f)(x, y) == f(x, y)", function ()
+      local f = function(x, y) return x + 1, y + 1 end
+      local ax, ay = func.compose(f)(1, 2)
+      local bx, by = f(1, 2)
+      assert.equals(ax, bx)
+      assert.equals(ay, by)
+    end)
+
+    it("compose(f, g)(x, y) == f(g(x, y))", function ()
+      local f = function(x, y) return x + 1, y + 1 end
+      local g = function(x, y) return x + 2, y + 2 end
+      local ax, ay = func.compose(f, g)(1, 2)
+      local bx, by = f(g(1, 2))
+      assert.equals(ax, bx)
+      assert.equals(ay, by)
+    end)
+
+    it("compose(f, g, h)(x, y) == f(g(h(x, y)))", function ()
+      local f = function(x, y) return x + 1, y + 1 end
+      local g = function(x, y) return x + 2, y + 2 end
+      local h = function(x, y) return x + 3, y + 3 end
+      local ax, ay = func.compose(f, g, h)(1, 2)
+      local bx, by = f(g(h(1, 2)))
+      assert.equals(ax, bx)
+      assert.equals(ay, by)
+    end)
+
+  end)
+
+end)


### PR DESCRIPTION
Previously, func.compose only supported two functions, as in:

  compose(print, string.upper)("hello") -- prints "HELLO"

This commit enables any number of functions to be composed by internally leveraging tablex.reduce to repeatedly apply functions.

For example:

  compose(bind1(add, 10), bind1(mul, 5), bind(div, _1, 3))(9)
    -- prints "25"

One can also pass functions as a table:

  compose({ bind1(add, 10), bind1(mul, 5), bind(div, _1, 3) })(9)
    -- prints "25"