### PR TITLE
Bump GitHub workflow actions to latest versions

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Luacheck
         uses: lunarmodules/luacheck@v1

--- a/.github/workflows/unix_build.yml
+++ b/.github/workflows/unix_build.yml
@@ -12,9 +12,9 @@ jobs:
         luaVersion: ["5.1", "5.2", "5.3", "5.4", "luajit-2.1.0-beta3", "luajit-openresty"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: leafo/gh-actions-lua@v8
+    - uses: leafo/gh-actions-lua@v9
       with:
         luaVersion: ${{ matrix.luaVersion }}
 


### PR DESCRIPTION
This PR bumps GitHub action workflows to latest versions, thus avoiding deprecation warnings.