### PR TITLE
docs: Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,16 +131,16 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
  - overhaul: `array2d` module was updated, got additional tests and several
    documentation updates
    [#377](https://github.com/lunarmodules/Penlight/pull/377)
- - feat: `aray2d` now accepts negative indices
+ - feat: `array2d` now accepts negative indices
  - feat: `array2d.row` added to align with `column`
  - fix: bad error message in `array2d.map`
  - fix: `array2d.flatten` now ensures to deliver a 'square' result if `nil` is
    encountered
  - feat: `array2d.transpose` added
  - feat: `array2d.swap_rows` and `array2d.swap_cols` now return the array
- - fix: `aray2d.range` correctly recognizes `R` column in spreadsheet format, was
+ - fix: `array2d.range` correctly recognizes `R` column in spreadsheet format, was
    mistaken for `R1C1` format.
- - fix: `aray2d.range` correctly recognizes 2 char column in spreadsheet format
+ - fix: `array2d.range` correctly recognizes 2 char column in spreadsheet format
  - feat: `array2d.default_range` added (previously private)
  - feat: `array2d.set` if used with a function now passes `i,j` to the function
    in line with the `new` implementation.
@@ -203,7 +203,7 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
 
   - `utils.quote_arg` will now optionally take an array of arguments and escape
     them all into a single string.
-  - `app.parse_args` now accepts a 3rd parameter with a list of valid flags and aliasses
+  - `app.parse_args` now accepts a 3rd parameter with a list of valid flags and aliases
   - `app.script_name` returns the name of the current script (previously a private function)
 
 ### Changes
@@ -366,7 +366,7 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
 
 ### Fixes
 
-  - func was broken: do NOT use ipairs to iterate if __index is overriden!
+  - func was broken: do NOT use ipairs to iterate if __index is overridden!
   - issue #133 pretty.read (naively) confused by unbalanced brackets
   - xml attribute underscore fix for simple parser
   - Fix path.normpath
@@ -491,7 +491,7 @@ particularly convenient for using from Moonscript.
 - array2d.product was broken; more sensible implementation
 - array2d.range, .slice, .write were broken
 - text optional operator % overload broken for 'fmt % fun'; new tests
-- a few occurances of non-existent function utils.error removed
+- a few occurrences of non-existent function utils.error removed
 
 
 ## 0.9.6 (2011-09-11)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Here's how to go about contributing to Penlight:
 
 1. [Fork the repository](https://github.com/lunarmodules/Penlight/fork) to
 your Github account.
-2. Create a *topical branch* - a branch whose name is succint but explains what
+2. Create a *topical branch* - a branch whose name is succinct but explains what
 you're doing, such as _"added-klingon-cloacking-device"_ - from `master` branch.
 3. Make your changes, committing at logical breaks.
 4. Push your branch to your personal account

--- a/docs_topics/01-introduction.md
+++ b/docs_topics/01-introduction.md
@@ -175,7 +175,7 @@ For example,
 
     return M
 
-If you were to accidently type `mymod.Answer()`, then you would get a runtime
+If you were to accidentally type `mymod.Answer()`, then you would get a runtime
 error: "variable 'Answer' is not declared in 'mymod'".
 
 This can be applied to existing modules. You may desire to have the same level
@@ -231,7 +231,7 @@ a function to all elements of a list is a common operation:
         res[i] = fun(ls[i])
     end
 
-This can be efficiently and succintly expressed as `ls:map(fun)`. Not only is
+This can be efficiently and succinctly expressed as `ls:map(fun)`. Not only is
 there less typing but the intention of the code is clearer. If readers of your
 code spend too much time trying to guess your intention by analyzing your loops,
 then you have failed to express yourself clearly. Similarly, `ls:filter('>',0)`
@@ -330,7 +330,7 @@ for functions which don't access any globals.
 
 `app.parse_args` is a simple command-line argument parser. If called without any
 arguments, it tries to use the global `arg` array.  It returns the _flags_
-(options begining with '-') as a table of name/value pairs, and the _arguments_
+(options beginning with '-') as a table of name/value pairs, and the _arguments_
 as an array.  It knows about long GNU-style flag names, e.g. `--value`, and
 groups of short flags are understood, so that `-ab` is short for `-a -b`. The
 flags result would then look like `{value=true,a=true,b=true}`.

--- a/docs_topics/02-arrays.md
+++ b/docs_topics/02-arrays.md
@@ -129,7 +129,7 @@ there is already `pop` (remove and return last value) and `append` acts like
 `push` (add a value to the end). `push` is provided as an alias for `append`, and
 the other stack operation (size) is simply the size operator `#`.  Queues can
 also be implemented; you use `pop` to take values out of the queue, and `put` to
-insert a value at the begining.
+insert a value at the beginning.
 
 You may derive classes from `List`, and since the list-returning methods
 are covariant, the result of `slice` etc will return lists of the derived type,

--- a/docs_topics/03-strings.md
+++ b/docs_topics/03-strings.md
@@ -37,7 +37,7 @@ Most of these can be fairly easily implemented using the Lua string library,
 which is more general and powerful. But they are convenient operations to have
 easily at hand. Note that can be injected into the `string` table if you use
 `stringx.import`, but a simple alias like `local stringx = require 'pl.stringx'`
-is preferrable. This is the recommended practice when writing modules for
+is preferable. This is the recommended practice when writing modules for
 consumption by other people, since it is bad manners to change the global state
 of the rest of the system. Magic may be used for convenience, but there is always
 a price.
@@ -104,7 +104,7 @@ lines that fit into a desired line width. As an extension, there is also `indent
 for indenting multiline strings.
 
 New in Penlight with the 0.9 series is `text.format_operator`. Calling this
-enables Python-style string formating using the modulo operator `%`:
+enables Python-style string formatting using the modulo operator `%`:
 
     > text.format_operator()
     > = '%s[%d]' % {'dog',1}
@@ -126,7 +126,7 @@ Preprocessor](http://lua-users.org/wiki/SlightlyLessSimpleLuaPreprocessor).  Thi
 allows you to mix Lua code with your templates in a straightforward way. There
 are only two rules:
 
-  - Lines begining with `#` are Lua
+  - Lines beginning with `#` are Lua
   - Otherwise, anything inside `$()` is a Lua expression.
 
 So a template generating an HTML list would look like this:
@@ -223,6 +223,6 @@ takes the same arguments as standard file objects:
 string.
 
 `stringio.create` creates a writeable file-like object. You then use `write` to
-this stream, and finally extract the builded string using `value`.  This 'string
+this stream, and finally extract the built string using `value`.  This 'string
 builder' pattern is useful for efficiently creating large strings.
 

--- a/docs_topics/04-paths.md
+++ b/docs_topics/04-paths.md
@@ -90,7 +90,7 @@ For example, this little script converts a file into upper case:
 	text = assert(file.read(arg[1]))
     assert(file.write(arg[2],text:upper()))
 
-Copying files is suprisingly tricky. `file.copy` and `file.move` attempt to use
+Copying files is surprisingly tricky. `file.copy` and `file.move` attempt to use
 the best implementation possible. On Windows, they link to the API functions
 `CopyFile` and `MoveFile`, but only if the `alien` package is installed (this is
 true for Lua for Windows.) Otherwise, the system copy command is used. This can
@@ -109,7 +109,7 @@ table, unlike `lfs.dir` which returns an iterator.)
 
 `dir.makepath` can create a full path, creating subdirectories as necessary;
 `rmtree` is the Nuclear Option of file deleting functions, since it will
-recursively clear out and delete all directories found begining at a path (there
+recursively clear out and delete all directories found beginning at a path (there
 is a similar function with this name in the Python `shutils` module.)
 
     > = dir.makepath 't\\temp\\bonzo'

--- a/docs_topics/05-dates.md
+++ b/docs_topics/05-dates.md
@@ -43,7 +43,7 @@ you full control of the format for both parsing and displaying dates:
     > = amer:tostring(d)
     04/10/2010
 
-With the 0.9.7 relase, the `Date` constructor has become more flexible. You may
+With the 0.9.7 release, the `Date` constructor has become more flexible. You may
 omit any of the 'year', 'month' or 'day' fields:
 
     > = Date { year = 2008 }

--- a/docs_topics/06-data.md
+++ b/docs_topics/06-data.md
@@ -704,7 +704,7 @@ gracefully.)
 The scanners all have a second optional argument, which is a table which controls
 whether you want to exclude spaces and/or comments. The default for `lexer.lua`
 is `{space=true,comments=true}`.  There is a third optional argument which
-determines how string and number tokens are to be processsed.
+determines how string and number tokens are to be processed.
 
 The ultimate highly-structured data is of course, program source. Here is a
 snippet from 'text-lexer.lua':

--- a/docs_topics/07-functional.md
+++ b/docs_topics/07-functional.md
@@ -54,7 +54,7 @@ Sequences can be _combined_, either by 'zipping' them or by concatenating them.
     3
 
 `seq.printall` is useful for printing out single-valued sequences, and provides
-some finer control over formating, such as a delimiter, the number of fields per
+some finer control over formatting, such as a delimiter, the number of fields per
 line, and a format string to use (@see string.format)
 
     > seq.printall(seq.random(10))
@@ -82,7 +82,7 @@ original table (equivalent to `tablex.filter(ls, '>', 0)`)
 
     ls = seq.copy(seq.filter(ls, '>', 0))
 
-We're already encounted `seq.sum` when discussing `input.numbers`. This can also
+We're already encountered `seq.sum` when discussing `input.numbers`. This can also
 be expressed with `seq.reduce`:
 
     > seq.reduce(function(x,y) return x + y end, seq.list{1,2,3,4})
@@ -289,7 +289,7 @@ I'm emphasizing that a comprehension is a function which can take a list argumen
     {20,40,60}
 
 Here is a somewhat more explicit way of saying the same thing; `_1` is a
-_placeholder_ refering to the _first_ argument passed to the comprehension.
+_placeholder_ referring to the _first_ argument passed to the comprehension.
 
     > = C '2*x for _,x in pairs(_1)' {10,20,30}
     {20,40,60}
@@ -366,7 +366,7 @@ arguments where the first argument is bound to some value:
     > tablex.filter({1,-2,10,-1,2},bind1(ops.le,0))
     {1,10,2}
 
-The last example unfortunately reads backwards, because `bind1` alway binds the
+The last example unfortunately reads backwards, because `bind1` always binds the
 first argument!  Also unfortunately, in my youth I confused 'currying' with
 'partial application', so the old name for `bind1` is `curry` - this alias still exists.
 
@@ -441,7 +441,7 @@ Functions of up to 5 arguments can be generated.
     > = tablex.map2(_1+_2,{1,2,3}, {10,20,30})
     {11,22,33}
 
-These expressions can use arbitrary functions, altho they must first be
+These expressions can use arbitrary functions, although they must first be
 registered with the functional library. `func.register` brings in a single
 function, and `func.import` brings in a whole table of functions, such as `math`.
 
@@ -458,7 +458,7 @@ A common operation is calling a method of a set of objects:
     {'o','f','x'}
 
 There are some restrictions on what operators can be used in PEs. For instance,
-because the `__len` metamethod cannot be overriden by plain Lua tables, we need
+because the `__len` metamethod cannot be overridden by plain Lua tables, we need
 to define a special function to express `#_1':
 
     > = tablex.map(Len(_1), {'one','four','x'})

--- a/docs_topics/08-additional.md
+++ b/docs_topics/08-additional.md
@@ -423,7 +423,7 @@ perfectly legal to have '-vvv'. But normally the value of args.v is just a simpl
     vlevel = not args.v[1] and 0 or #args.v
     print(vlevel)
 
-The vlevel assigment is a bit of Lua voodoo, so consider the cases:
+The vlevel assignment is a bit of Lua voodoo, so consider the cases:
 
     * No -v flag, v is just { false }
     * One -v flags, v is { true }

--- a/lua/pl/List.lua
+++ b/lua/pl/List.lua
@@ -116,7 +116,7 @@ function List:insert(i, x)
     return self
 end
 
---- Insert an item at the begining of the list.
+--- Insert an item at the beginning of the list.
 -- @param x a data item
 -- @return the list
 function List:put (x)
@@ -526,7 +526,7 @@ function List:iter ()
     return iter(self)
 end
 
---- Create an iterator over a seqence.
+--- Create an iterator over a sequence.
 -- This captures the Python concept of 'sequence'.
 -- For tables, iterates over all values with integer indices.
 -- @param seq a sequence; a string (over characters), a table, a file object (over lines) or an iterator function

--- a/lua/pl/app.lua
+++ b/lua/pl/app.lua
@@ -144,7 +144,7 @@ end
 -- Multiple short args can be combined like so: ( `-abcd`).
 --
 -- When specifying the `flags_valid` parameter, its contents can also contain
--- aliasses, to convert short/long flags to the same output name. See the
+-- aliases, to convert short/long flags to the same output name. See the
 -- example below.
 --
 -- Note: if a flag is repeated, the last value wins.
@@ -163,7 +163,7 @@ end
 --      { "hello", "world" },  -- list of flags taking values
 --      { "l", "a", "b"})      -- list of allowed flags (value ones will be added)
 --
--- -- More complex example using aliasses:
+-- -- More complex example using aliases:
 -- local valid = {
 --     long = "l",           -- if 'l' is specified, it is reported as 'long'
 --     new = { "n", "old" }, -- here both 'n' and 'old' will go into 'new'
@@ -206,16 +206,16 @@ function app.parse_args (args,flags_with_values, flags_valid)
         valid = setmetatable({},{ __index = function(_, key) return key end })
     else
         valid = {}
-        for k,aliasses in pairs(flags_valid) do
+        for k,aliases in pairs(flags_valid) do
             if type(k) == "number" then         -- array/list entry
-                k = aliasses
+                k = aliases
             end
-            if type(aliasses) == "string" then  -- single alias
-                aliasses = { aliasses }
+            if type(aliases) == "string" then  -- single alias
+                aliases = { aliases }
             end
-            if type(aliasses) == "table" then   -- list of aliasses
+            if type(aliases) == "table" then   -- list of aliases
                 -- it's the alternate name, so add the proper mappings
-                for i, alias in ipairs(aliasses) do
+                for i, alias in ipairs(aliases) do
                     valid[alias] = k
                 end
             end
@@ -236,7 +236,7 @@ function app.parse_args (args,flags_with_values, flags_valid)
     end
 
     -- now check that all flags with values are reported as such under all
-    -- of their aliasses
+    -- of their aliases
     for k, main_alias in pairs(valid) do
         if with_values[main_alias] then
             with_values[k] = true

--- a/lua/pl/array2d.lua
+++ b/lua/pl/array2d.lua
@@ -189,7 +189,7 @@ function array2d.flatten (t)
     return makelist(res)
 end
 
---- reshape a 2D array. Reshape the aray by specifying a new nr of rows.
+--- reshape a 2D array. Reshape the array by specifying a new nr of rows.
 -- @array2d t 2d array
 -- @int nrows new number of rows
 -- @bool co use column-order (Fortran-style) (default false)
@@ -266,7 +266,7 @@ end
 --- extract the specified columns.
 -- @array2d t 2d array
 -- @tparam {int} cidx a table of column indices
--- @return a new 2d array with the extracted colums
+-- @return a new 2d array with the extracted columns
 function array2d.extract_cols (t,cidx)
     assert_arg(1,t,'table')
     local res = {}

--- a/lua/pl/class.lua
+++ b/lua/pl/class.lua
@@ -1,4 +1,4 @@
---- Provides a reuseable and convenient framework for creating classes in Lua.
+--- Provides a reusable and convenient framework for creating classes in Lua.
 -- Two possible notations:
 --
 --    B = class(A)
@@ -25,7 +25,7 @@ local function call_ctor (c,obj,...)
             init = rawget(parent_with_init, '_init')
             parent_with_init = rawget(parent_with_init, '_parent_with_init')
         end
-        if parent_with_init then -- super() points to one above whereever _init came from
+        if parent_with_init then -- super() points to one above wherever _init came from
             rawset(obj,'super',function(obj,...)
                 call_ctor(parent_with_init,obj,...)
             end)

--- a/lua/pl/config.lua
+++ b/lua/pl/config.lua
@@ -50,7 +50,7 @@ local config = {}
 
 --- like `io.lines`, but allows for lines to be continued with '`\`'.
 -- @param file a file-like object (anything where read() returns the next line) or a filename.
--- Defaults to stardard input.
+-- Defaults to standard input.
 -- @return an iterator over the lines, or nil
 -- @return error 'not a file-like object' or 'file is nil'
 function config.lines(file)

--- a/lua/pl/data.lua
+++ b/lua/pl/data.lua
@@ -217,7 +217,7 @@ function data.read(file,cnfg)
 
     -- note that using dot as the thousands separator (@thousands_dot)
     -- requires a special conversion function! For CSV, _empty fields_ are
-    -- considered to default to numerial zeroes.
+    -- considered to default to numerical zeroes.
     local tonumber = tonumber
     local function try_number(x)
         if thousands_dot then x = x:gsub('%.(...)','%1') end

--- a/lua/pl/func.lua
+++ b/lua/pl/func.lua
@@ -252,7 +252,7 @@ function repr (e,lastpred)
 end
 func.repr = repr
 
--- collect all the non-PE values in this PE into vlist, and replace each occurence
+-- collect all the non-PE values in this PE into vlist, and replace each occurrence
 -- with a constant PH (_C1, etc). Return the maximum placeholder index found.
 local collect_values
 function collect_values (e,vlist)

--- a/lua/pl/import_into.lua
+++ b/lua/pl/import_into.lua
@@ -1,6 +1,6 @@
 --------------
 -- PL loader, for loading all PL libraries, only on demand.
--- Whenever a module is implicitly accesssed, the table will have the module automatically injected.
+-- Whenever a module is implicitly accessed, the table will have the module automatically injected.
 -- (e.g. `_ENV.tablex`)
 -- then that module is dynamically loaded. The submodules are all brought into
 -- the table that is provided as the argument, or returned in a new table.

--- a/lua/pl/init.lua
+++ b/lua/pl/init.lua
@@ -1,6 +1,6 @@
 --------------
 -- Entry point for loading all PL libraries only on demand, into the global space.
--- Requiring 'pl' means that whenever a module is implicitly accesssed
+-- Requiring 'pl' means that whenever a module is implicitly accessed
 -- (e.g. `utils.split`)
 -- then that module is dynamically loaded. The submodules are all brought into
 -- the global space.

--- a/lua/pl/permute.lua
+++ b/lua/pl/permute.lua
@@ -82,7 +82,7 @@ end
 
 --- an iterator over all permutations of the elements of the given lists.
 -- @param ... list-like tables, they are nil-safe if a length-field `n` is provided (see `utils.pack`)
--- @return an iterator which provides the next permutation as return values in the same order as the provided lists, preceeded by an index
+-- @return an iterator which provides the next permutation as return values in the same order as the provided lists, preceded by an index
 -- @usage
 -- local strs = utils.pack("one", nil, "three")  -- adds an 'n' field for nil-safety
 -- local bools = utils.pack(true, false)

--- a/lua/pl/stringx.lua
+++ b/lua/pl/stringx.lua
@@ -450,7 +450,7 @@ local function _partition(p,delim,fn)
     end
 end
 
---- partition the string using first occurance of a delimiter
+--- partition the string using first occurrence of a delimiter
 -- @string s the string
 -- @string ch delimiter (match as plain string, no patterns)
 -- @return part before ch
@@ -464,7 +464,7 @@ function stringx.partition(s,ch)
     return _partition(s,ch,stringx.lfind)
 end
 
---- partition the string p using last occurance of a delimiter
+--- partition the string p using last occurrence of a delimiter
 -- @string s the string
 -- @string ch delimiter (match as plain string, no patterns)
 -- @return part before ch
@@ -736,7 +736,7 @@ end
 
 
 
---- Miscelaneous
+--- Miscellaneous
 -- @section misc
 
 --- return an iterator over all lines in a string
@@ -754,7 +754,7 @@ function stringx.lines(s)
     return s:gmatch('([^\n]*)\n')
 end
 
---- inital word letters uppercase ('title case').
+--- initial word letters uppercase ('title case').
 -- Here 'words' mean chunks of non-space characters.
 -- @string s the string
 -- @return a string with each word's first letter uppercase
@@ -775,7 +775,7 @@ do
   --- Return a shortened version of a string.
   -- Fits string within w characters. Removed characters are marked with ellipsis.
   -- @string s the string
-  -- @int w the maxinum size allowed
+  -- @int w the maximum size allowed
   -- @bool tail true if we want to show the end of the string (head otherwise)
   -- @usage ('1234567890'):shorten(8) == '12345...'
   -- @usage ('1234567890'):shorten(8, true) == '...67890'
@@ -849,7 +849,7 @@ end
 
 --- Python-style formatting operator.
 -- Calling `text.format_operator()` overloads the % operator for strings to give
--- Python/Ruby style formated output.
+-- Python/Ruby style formatted output.
 -- This is extended to also do template-like substitution for map-like data.
 --
 -- Note this goes further than the original, and will allow these cases:
@@ -859,7 +859,7 @@ end
 -- 3. a map of var=value pairs
 -- 4. a function, as in gsub
 --
--- For the second two cases, it uses $-variable substituion.
+-- For the second two cases, it uses $-variable substitution.
 --
 -- When called, this function will monkey-patch the global `string` metatable by
 -- adding a `__mod` method.

--- a/lua/pl/utils.lua
+++ b/lua/pl/utils.lua
@@ -301,7 +301,7 @@ end
 -- non-existing values, and/or converting strings/identifiers to other values.
 --
 -- Calling on the object does the same, but returns a soft error; `nil + err`, if
--- the call is succesful (the key exists), it will return the value.
+-- the call is successful (the key exists), it will return the value.
 --
 -- When calling with varargs or an array the values will be equal to the keys.
 -- The enum object is read-only.
@@ -695,7 +695,7 @@ end
 -- @param s The input string
 -- @param re optional A Lua string pattern; defaults to '%s+'
 -- @param plain optional If truthy don't use Lua patterns
--- @param n optional maximum number of elements (if there are more, the last will remian un-split)
+-- @param n optional maximum number of elements (if there are more, the last will remain un-split)
 -- @return a list-like table
 -- @raise error if s is not a string
 -- @see splitv

--- a/lua/pl/xml.lua
+++ b/lua/pl/xml.lua
@@ -256,7 +256,7 @@ function Doc:reset()
 end
 
 
---- Append a child to the currrent Node (ignoring current position).
+--- Append a child to the current Node (ignoring current position).
 -- @param child a child node (either text or a document)
 -- @return the current node (`self`)
 -- @usage
@@ -292,7 +292,7 @@ end
 
 
 --- Set attributes of a document node.
--- Will add/overwite values, but will not remove existing ones.
+-- Will add/overwrite values, but will not remove existing ones.
 -- Operates on the Node itself, will not take position into account.
 -- @tparam table t a table containing attribute/value pairs
 -- @return the current node (`self`)
@@ -428,7 +428,7 @@ do
   -- @param self document node to traverse
   -- @param tag tag-name to look for
   -- @param list array table to add the matching ones to
-  -- @param recurse if truthy, recursivly search the node
+  -- @param recurse if truthy, recursively search the node
   local function _children_with_name(self, tag, list, recurse)
     -- TODO: protect against recursion
     for _, child in ipairs(self) do
@@ -923,7 +923,7 @@ local html_empty_elements = { --lists all HTML empty (void) elements
 }
 
 --- Parse a well-formed HTML file as a string.
--- Tags are case-insenstive, DOCTYPE is ignored, and empty elements can be .. empty.
+-- Tags are case-insensitive, DOCTYPE is ignored, and empty elements can be .. empty.
 -- @param s the HTML
 function _M.parsehtml(s)
     return _M.basic_parse(s,false,true)

--- a/spec/array2d_spec.lua
+++ b/spec/array2d_spec.lua
@@ -218,7 +218,7 @@ describe("pl.array2d", function()
   end)
 
   describe("extract_cols()", function()
-    it("extracts colums", function()
+    it("extracts columns", function()
       local a = {{ 1, 2, 3},
                  { 4, 5, 6},
                  { 7, 8, 9},
@@ -446,7 +446,7 @@ describe("pl.array2d", function()
   end)
 
   describe("move()", function()
-    it("moves block to destination aray", function()
+    it("moves block to destination array", function()
       local a = array2d.new(4,4,0)
       local b = array2d.new(3,3,1)
       array2d.move(a,2,2,b)

--- a/tests/test-app.lua
+++ b/tests/test-app.lua
@@ -267,7 +267,7 @@ do -- app.parse_args
       }, s)
 
 
-    -- specify valid flags and aliasses
+    -- specify valid flags and aliases
     local args = utils.split("-a -b value -e -f3")
     local t,s = app.parse_args(args,
       {
@@ -276,7 +276,7 @@ do -- app.parse_args
       }, {
         bully = "b",   -- b with value will be reported as 'bully', alias as string
         a = true,      -- hash-type value
-        c = { "d", "e" }, -- e will be reported as c, aliasses as list/table
+        c = { "d", "e" }, -- e will be reported as c, aliases as list/table
       })
     asserteq(t, {
         a = true,

--- a/tests/test-config.lua
+++ b/tests/test-config.lua
@@ -195,7 +195,7 @@ MemFree:          220292 kB
  }
 )
 
--- altho this works, rather use pl.data.read for this kind of purpose.
+-- although this works, rather use pl.data.read for this kind of purpose.
 testconfig ([[
 # this is just a set of comma-separated values
 1000,444,222

--- a/tests/test-func.lua
+++ b/tests/test-func.lua
@@ -80,7 +80,7 @@ asserteq (map(_1:sub(1,2),{'one','four'}),{'on','fo'})
 --~ -- or you can do this using List:map
 asserteq( List({'one','four'}):map(_1:sub(1,2)), List{'on','fo'})
 
---~ -- note that Len can't be represented generally by #, since this can only be overriden by userdata
+--~ -- note that Len can't be represented generally by #, since this can only be overridden by userdata
 asserteq( map(Len(_1),{'one','four'}),  {3,4} )
 
 --~ -- simularly, 'and' and 'or' are not really operators in Lua, so we need a function notation for them


### PR DESCRIPTION
This PR fixes various typos I spotted in the documentation.

I tried to regenerate the docs using `ldoc` (version 1.4.6). However I realized that not only typos were changed, but also the format of some links, ... . Therefore, I'm leaving regeneration of docs up to you, feel free to push doc changes on my branch `fix-typos`.