### PR TITLE
enhance(template): Preserve line numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ see [CONTRIBUTING.md](CONTRIBUTING.md#release-instructions-for-a-new-version) fo
    [#447](https://github.com/lunarmodules/Penlight/pull/447)
  - fix(template) using `%` as an escape character caused the expression to not be recognized
    [#452](https://github.com/lunarmodules/Penlight/pull/452)
+ - enhance(template): Preserve line numbers
+   [#468](https://github.com/lunarmodules/Penlight/pull/468)
 
 ## 1.13.1 (2022-Jul-22)
  - fix: `warn` unquoted argument

--- a/tests/test-template.lua
+++ b/tests/test-template.lua
@@ -262,7 +262,63 @@ asserteq(code, [[return "<ul>\
 <p>a paragraph</p>\
 <p>a paragraph</p>\
 </ul>\
-"]])
+";]])
+
+
+
+--------------------------------------------------
+-- Test template preserves line numbers, both when
+-- stripping and not stripping newlines
+local tmpl = [[
+# local function foo(x)
+  a$(x)b$(x + 1)c
+# return x + 2
+# end
+Hello
+there
+
+
+# foo(1)
+foo$(foo)bar
+# --
+]]
+local expected_num = select(2, string.gsub(tmpl, "\n", "\n"))
+
+-- Trailing newline, no newline stripping
+local t, err = template.compile(tmpl, { debug = true })
+local res, err, code = t:render(my_env)
+--print(res, err, code)
+
+assert(res, "rendering should not fail here")
+asserteq(select(2, string.gsub(code, "\n", "\n")), expected_num)
+
+-- Trailing newline, with newline stripping
+local t, err = template.compile(tmpl, { debug = true, newline = true })
+local res, err, code = t:render(my_env)
+--print(res, err, code)
+
+assert(res, "rendering should not fail here")
+asserteq(select(2, string.gsub(code, "\n", "\n")), expected_num)
+
+
+tmpl = string.sub(code, 1, -2) -- Remove the trailing newline
+-- num_expected remains unchanged because the template will append a trailing newline
+
+-- No trailing newline, no newline stripping
+local t, err = template.compile(tmpl, { debug = true })
+local res, err, code = t:render(my_env)
+--print(res, err, code)
+
+assert(res, "rendering should not fail here")
+asserteq(select(2, string.gsub(code, "\n", "\n")), expected_num)
+
+-- No trailing newline, with newline stripping
+local t, err = template.compile(tmpl, { debug = true, newline = true })
+local res, err, code = t:render(my_env)
+--print(res, err, code)
+
+assert(res, "rendering should not fail here")
+asserteq(select(2, string.gsub(code, "\n", "\n")), expected_num)
 
 
 print("template: success")


### PR DESCRIPTION
This PR tweaks the `template` module to build intermediate template code where instructions have the same line numbers as in the original template.

For example, with the old behaviour, the template
```
# local foo = 1
a $(foo + 1) b
# bar()
```
would have resulted in the following intermediate code:
```lua
return function()
local __R_size, __R_table, __tostring = 0, {}, __tostring
 local foo = 1
__R_size = __R_size + 1; __R_table[__R_size] = "a "
__R_size = __R_size + 1; __R_table[__R_size] = __tostring((foo + 1) or '')
__R_size = __R_size + 1; __R_table[__R_size] = " b\
"
 bar()
return __R_table
end
```
If `bar()` were to produce an error, Lua would report it as occurring on line 8, which is completely unhelpful. However, after this PR, the above template will produce the following code:
```lua
return function() local __R_size, __R_table, __tostring = 0, {}, __tostring;  local foo = 1
 __R_size = __R_size + 1; __R_table[__R_size] = "a "; __R_size = __R_size + 1; __R_table[__R_size] = __tostring((foo + 1) or ''); __R_size = __R_size + 1; __R_table[__R_size] = " b\
"; bar()
return __R_table; end
```
While less readable, any errors will now be reported as occurring on the same line as in the original template, which greatly eases debugging, since it's often easy to pinpoint the source of error just by looking at the right line in the template string.

Essentially, this PR only swaps out some newlines for spaces and semicolons; the actual rendering behaviour of templates should remain unchanged. It also works when the `newline` option is truthy; stripped newlines aren't removed completely, just moved out of the appender statements and into the intermediate Lua code.