### PR TITLE
fix(docs): add 2 missing methods of Map.lua

### DIFF
--- a/lua/pl/Map.lua
+++ b/lua/pl/Map.lua
@@ -37,10 +37,14 @@ local function makelist(t)
     return setmetatable(t, require('pl.List'))
 end
 
---- list of keys.
+--- return a List of all keys.
+-- @class function
+-- @name Map:keys
 Map.keys = tablex.keys
 
---- list of values.
+--- return a List of all values.
+-- @class function
+-- @name Map:keys
 Map.values = tablex.values
 
 --- return an iterator over all key-value pairs.
@@ -48,7 +52,7 @@ function Map:iter ()
     return pairs(self)
 end
 
---- return a List of all key-value pairs, sorted by the keys.
+--- return a List of all key-value pairs, sorted by the keys in ascending order.
 function Map:items()
     local ls = makelist(tablex.pairmap (function (k,v) return makelist {k,v} end, self))
     ls:sort(function(t1,t2) return t1[1] < t2[1] end)

--- a/lua/pl/Map.lua
+++ b/lua/pl/Map.lua
@@ -44,7 +44,7 @@ Map.keys = tablex.keys
 
 --- return a List of all values.
 -- @class function
--- @name Map:keys
+-- @name Map:values
 Map.values = tablex.values
 
 --- return an iterator over all key-value pairs.


### PR DESCRIPTION
The `keys`and `values` are improperly listed as fields instead of methods. There is no such a problem for `OrderedMap`.
The documentation for `items` explicitly mention the ordering for keys