### PR TITLE
Documentation: fix lfs, stevedonovan and orbit broken links

### DIFF
--- a/docs_topics/01-introduction.md
+++ b/docs_topics/01-introduction.md
@@ -41,10 +41,10 @@ the order, so that the function is passed the value and then the key. Although
 perverse, this matches the intended use better.
 
 The only important external dependence of Penlight is
-[LuaFileSystem](http://keplerproject.github.com/luafilesystem/manual.html)
+[LuaFileSystem](https://lunarmodules.github.io/luafilesystem/manual.html)
 (`lfs`), and if you want `dir.copyfile` to work cleanly on Windows, you will need
-either [alien](http://alien.luaforge.net/) or be using
-[LuaJIT](http://luajit.org) as well. (The fallback is to call the equivalent
+either [alien](https://github.com/mascarenhas/alien) or be using
+[LuaJIT](https://luajit.org) as well. (The fallback is to call the equivalent
 shell commands.)
 
 ### To Inject or not to Inject?
@@ -311,7 +311,7 @@ upfront, since in general you won't know what values are needed.
 
 Penlight is fully compatible with Lua 5.1, 5.2 and LuaJIT 2. To ensure this,
 `utils` also defines the global Lua 5.2
-[load](http://www.lua.org/work/doc/manual.html#pdf-load) function as `utils.load`
+[load](https://www.lua.org/work/doc/manual.html#pdf-load) function as `utils.load`
 
  * the input (either a string or a function)
  * the source name used in debug information
@@ -483,7 +483,7 @@ if no `__tostring` method is explicitly defined.
 So `Alice = class(); Alice._name = 'Alice'` is exactly the same as `class.Alice()`.
 
 This useful notation is borrowed from Hugo Etchegoyen's
-[classlib](http://lua-users.org/wiki/MultipleInheritanceClasses) which further
+[classlib](https://lua-users.org/wiki/MultipleInheritanceClasses) which further
 extends this concept to allow for multiple inheritance. Notice that the
 more convenient form puts the class name in the _current environment_! That is,
 you may use it safely within modules using the old-fashioned `module()`

--- a/docs_topics/02-arrays.md
+++ b/docs_topics/02-arrays.md
@@ -520,7 +520,7 @@ compulsory way to use Penlight table operations.
 Two-dimensional tables are of course easy to represent in Lua, for instance
 `{{1,2},{3,4}}` where we store rows as subtables and index like so `A[col][row]`.
 This is the common representation used by matrix libraries like
-[LuaMatrix](http://lua-users.org/wiki/LuaMatrix). `pl.array2d` does not provide
+[LuaMatrix](https://lua-users.org/wiki/LuaMatrix). `pl.array2d` does not provide
 matrix operations, since that is the job for a specialized library, but rather
 provides generalizations of the higher-level operations provided by `pl.tablex`
 for one-dimensional arrays.

--- a/docs_topics/03-strings.md
+++ b/docs_topics/03-strings.md
@@ -122,7 +122,7 @@ metatable. But in your own scripts you can feel free to do this.
 ### Another Style of Template
 
 A new module is `template`, which is a version of Rici Lake's [Lua
-Preprocessor](http://lua-users.org/wiki/SlightlyLessSimpleLuaPreprocessor).  This
+Preprocessor](https://lua-users.org/wiki/SlightlyLessSimpleLuaPreprocessor).  This
 allows you to mix Lua code with your templates in a straightforward way. There
 are only two rules:
 

--- a/docs_topics/05-dates.md
+++ b/docs_topics/05-dates.md
@@ -7,7 +7,7 @@ NOTE: the Date module is deprecated
 ### Creating and Displaying Dates
 
 The `Date` class provides a simplified way to work with [date and
-time](http://www.lua.org/pil/22.1.html) in Lua; it leans heavily on the functions
+time](https://www.lua.org/pil/22.1.html) in Lua; it leans heavily on the functions
 `os.date` and `os.time`.
 
 A `Date` object can be constructed from a table, just like with `os.time`.

--- a/docs_topics/06-data.md
+++ b/docs_topics/06-data.md
@@ -353,7 +353,7 @@ this data. In fact, these functions are available as methods; e.g.
     v = data.read('dat.txt'):flatten()
 
 The data is also in exactly the right shape to be treated as matrices by
-[LuaMatrix](http://lua-users.org/wiki/LuaMatrix):
+[LuaMatrix](https://lua-users.org/wiki/LuaMatrix):
 
     > matrix = require 'matrix'
     > m = matrix(data.read 'mat.txt')
@@ -775,7 +775,7 @@ specialized library.
 
 #### Parsing and Pretty-Printing
 
-The semi-standard XML parser in the Lua universe is [lua-expat](http://matthewwild.co.uk/projects/luaexpat/).
+The semi-standard XML parser in the Lua universe is [lua-expat](https://lunarmodules.github.io/luaexpat/).
 In particular,
 it has a function called `lxp.lom.parse` which will parse XML into the Lua Object
 Model (LOM) format. However, it does not provide a way to convert this data back
@@ -846,7 +846,7 @@ There is a fourth argument which is the _attribute indent_:
 #### Parsing and Working with Configuration Files
 
 It's common to find configurations expressed with XML these days. It's
-straightforward to 'walk' the [LOM](http://matthewwild.co.uk/projects/luaexpat/lom.html)
+straightforward to 'walk' the [LOM](https://lunarmodules.github.io/luaexpat/lom.html)
 data and extract the data in the form you want:
 
     require 'pl'
@@ -960,7 +960,7 @@ Getting the names of the providers per-country is straightforward:
 #### Generating XML with 'xmlification'
 
 This feature is inspired by the `htmlify` function used by
-[Orbit](http://keplerproject.github.com/orbit/) to simplify HTML generation,
+[Orbit](https://keplerproject.github.io/orbit/) to simplify HTML generation,
 except that no function environment magic is used; the `tags` function returns a
 set of _constructors_ for elements of the given tag names.
 
@@ -1047,9 +1047,9 @@ extract values from it using a pattern.
 
 A common use of this is parsing the XML result of API queries.  The
 [(undocumented and subsequently discontinued) Google Weather
-API](http://blog.programmableweb.com/2010/02/08/googles-secret-weather-api/) is a
+API](https://blog.programmableweb.com/2010/02/08/googles-secret-weather-api/) is a
 good example. Grabbing the result of
-`http://www.google.com/ig/api?weather=Johannesburg,ZA" we get something like
+`https://www.google.com/ig/api?weather=Johannesburg,ZA" we get something like
 this, after pretty-printing:
 
     <xml_api_reply version='1'>

--- a/docs_topics/08-additional.md
+++ b/docs_topics/08-additional.md
@@ -373,7 +373,7 @@ array.
 Consider this implementation of the head utility from Mac OS X:
 
         -- implements a BSD-style head
-        -- (see http://www.manpagez.com/man/1/head/osx-10.3.php)
+        -- (see https://www.manpagez.com/man/1/head/osx-10.3.php)
 
         lapp = require ('pl.lapp')
 
@@ -528,7 +528,7 @@ And here we can see the output of `test.lua`:
 ### Simple Test Framework
 
 `pl.test` was originally developed for the sole purpose of testing Penlight itself,
-but you may find it useful for your own applications. ([There are many other options](http://lua-users.org/wiki/UnitTesting).)
+but you may find it useful for your own applications. ([There are many other options](https://lua-users.org/wiki/UnitTesting).)
 
 Most of the goodness is in `test.asserteq`.  It uses `tablex.deepcompare` on its two arguments,
 and by default quits the test application with a non-zero exit code, and an informative

--- a/lua/pl/path.lua
+++ b/lua/pl/path.lua
@@ -45,12 +45,12 @@ local function err_func(name, param, err, code)
 end
 
 --- Lua iterator over the entries of a given directory.
--- Implicit link to [`luafilesystem.dir`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
+-- Implicit link to [`luafilesystem.dir`](https://lunarmodules.github.io/luafilesystem/manual.html#dir)
 -- @function dir
 path.dir = lfs.dir
 
 --- Creates a directory.
--- Implicit link to [`luafilesystem.mkdir`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
+-- Implicit link to [`luafilesystem.mkdir`](https://lunarmodules.github.io/luafilesystem/manual.html#mkdir)
 -- @function mkdir
 path.mkdir = function(d)
   local ok, err, code = lfs.mkdir(d)
@@ -61,7 +61,7 @@ path.mkdir = function(d)
 end
 
 --- Removes a directory.
--- Implicit link to [`luafilesystem.rmdir`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
+-- Implicit link to [`luafilesystem.rmdir`](https://lunarmodules.github.io/luafilesystem/manual.html#rmdir)
 -- @function rmdir
 path.rmdir = function(d)
   local ok, err, code = lfs.rmdir(d)
@@ -72,7 +72,7 @@ path.rmdir = function(d)
 end
 
 --- Gets attributes.
--- Implicit link to [`luafilesystem.attributes`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
+-- Implicit link to [`luafilesystem.attributes`](https://lunarmodules.github.io/luafilesystem/manual.html#attributes)
 -- @function attrib
 path.attrib = function(d, r)
   local ok, err, code = attrib(d, r)
@@ -83,7 +83,7 @@ path.attrib = function(d, r)
 end
 
 --- Get the working directory.
--- Implicit link to [`luafilesystem.currentdir`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
+-- Implicit link to [`luafilesystem.currentdir`](https://lunarmodules.github.io/luafilesystem/manual.html#currentdir)
 -- @function currentdir
 path.currentdir = function()
   local ok, err, code = currentdir()
@@ -94,7 +94,7 @@ path.currentdir = function()
 end
 
 --- Gets symlink attributes.
--- Implicit link to [`luafilesystem.symlinkattributes`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
+-- Implicit link to [`luafilesystem.symlinkattributes`](https://lunarmodules.github.io/luafilesystem/manual.html#symlinkattributes)
 -- @function link_attrib
 path.link_attrib = function(d, r)
   local ok, err, code = link_attrib(d, r)
@@ -107,7 +107,7 @@ end
 --- Changes the working directory.
 -- On Windows, if a drive is specified, it also changes the current drive. If
 -- only specifying the drive, it will only switch drive, but not modify the path.
--- Implicit link to [`luafilesystem.chdir`](https://keplerproject.github.io/luafilesystem/manual.html#reference)
+-- Implicit link to [`luafilesystem.chdir`](https://lunarmodules.github.io/luafilesystem/manual.html#chdir)
 -- @function chdir
 path.chdir = function(d)
   local ok, err, code = lfs.chdir(d)


### PR DESCRIPTION
This is not ready to merge.

Some links were broken and have been fixed in files of the repo.

I could not build the documentation by myself with ldoc (error: unknown file attribute: b)
and I could not find a way to make `ldoc` replace "`lsf.dir`" in file
```
docs_topics/04-paths.md
```
 by
```
<a href="https://lunarmodules.github.io/luafilesystem/manual.html#dir">lfs.dir</a>
```
in file
```
docs/manual/04-paths.md.html
```
instead of
```
<a href="http://stevedonovan.github.io/lua-stdlibs/lfs.html#dir">lfs.dir</a>
```
which is the broken link
