### PR TITLE
Path.abspath

### DIFF
--- a/lua/pl/Map.lua
+++ b/lua/pl/Map.lua
@@ -37,10 +37,14 @@ local function makelist(t)
     return setmetatable(t, require('pl.List'))
 end
 
---- list of keys.
+--- return a List of all keys.
+-- @class function
+-- @name Map:keys
 Map.keys = tablex.keys
 
---- list of values.
+--- return a List of all values.
+-- @class function
+-- @name Map:keys
 Map.values = tablex.values
 
 --- return an iterator over all key-value pairs.
@@ -48,7 +52,7 @@ function Map:iter ()
     return pairs(self)
 end
 
---- return a List of all key-value pairs, sorted by the keys.
+--- return a List of all key-value pairs, sorted by the keys in ascending order.
 function Map:items()
     local ls = makelist(tablex.pairmap (function (k,v) return makelist {k,v} end, self))
     ls:sort(function(t1,t2) return t1[1] < t2[1] end)

--- a/lua/pl/Map.lua
+++ b/lua/pl/Map.lua
@@ -44,7 +44,7 @@ Map.keys = tablex.keys
 
 --- return a List of all values.
 -- @class function
--- @name Map:keys
+-- @name Map:values
 Map.values = tablex.values
 
 --- return an iterator over all key-value pairs.

--- a/lua/pl/path.lua
+++ b/lua/pl/path.lua
@@ -248,8 +248,8 @@ end
 -- @string[opt] pwd optional start path to use (default is current dir)
 function path.abspath(P,pwd)
     assert_string(1,P)
-    if pwd then assert_string(2,pwd) end
     local use_pwd = pwd ~= nil
+    if use_pwd then assert_string(2,pwd) end
     if not use_pwd and not currentdir() then return P end
     P = P:gsub('[\\/]$','')
     pwd = pwd or currentdir()


### PR DESCRIPTION
Actually `path.abspath(P,false)` is equivalent to `path.abspath(P)`. The purpose of this PR is to raise on the former call.
