### PR TITLE
chore(path): validate path if given in abspath

### DIFF
--- a/lua/pl/path.lua
+++ b/lua/pl/path.lua
@@ -248,8 +248,8 @@ end
 -- @string[opt] pwd optional start path to use (default is current dir)
 function path.abspath(P,pwd)
     assert_string(1,P)
-    if pwd then assert_string(2,pwd) end
     local use_pwd = pwd ~= nil
+    if use_pwd then assert_string(2,pwd) end
     if not use_pwd and not currentdir() then return P end
     P = P:gsub('[\\/]$','')
     pwd = pwd or currentdir()


### PR DESCRIPTION
Actually, `path.abspath(P,false)` is equivalent to `path.abspath(P)`. This PR raises on the former instruction.