### PR TITLE
Update class.lua

### DIFF
--- a/lua/pl/class.lua
+++ b/lua/pl/class.lua
@@ -227,7 +227,9 @@ class = setmetatable({},{
         return function(...)
             local c = _class(...)
             c._name = key
-            rawset(env,key,c)
+            if env then
+                rawset(env,key,c)
+            end
             return c
         end
     end


### PR DESCRIPTION
According to the documentation, `compat.getfenv` may return nil such that `env` may be nil.