### PR TITLE
docs: correct links to luafilesystem

### DIFF
--- a/docs/libraries/pl.path.html
+++ b/docs/libraries/pl.path.html
@@ -279,7 +279,7 @@
     </dt>
     <dd>
     Lua iterator over the entries of a given directory.
- Implicit link to <a href="https://keplerproject.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.dir</code></a>
+ Implicit link to <a href="https://lunarmodules.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.dir</code></a>
 
 
 
@@ -294,7 +294,7 @@
     </dt>
     <dd>
     Creates a directory.
- Implicit link to <a href="https://keplerproject.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.mkdir</code></a>
+ Implicit link to <a href="https://lunarmodules.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.mkdir</code></a>
 
 
 
@@ -309,7 +309,7 @@
     </dt>
     <dd>
     Removes a directory.
- Implicit link to <a href="https://keplerproject.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.rmdir</code></a>
+ Implicit link to <a href="https://lunarmodules.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.rmdir</code></a>
 
 
 
@@ -324,7 +324,7 @@
     </dt>
     <dd>
     Gets attributes.
- Implicit link to <a href="https://keplerproject.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.attributes</code></a>
+ Implicit link to <a href="https://lunarmodules.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.attributes</code></a>
 
 
 
@@ -339,7 +339,7 @@
     </dt>
     <dd>
     Get the working directory.
- Implicit link to <a href="https://keplerproject.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.currentdir</code></a>
+ Implicit link to <a href="https://lunarmodules.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.currentdir</code></a>
 
 
 
@@ -354,7 +354,7 @@
     </dt>
     <dd>
     Gets symlink attributes.
- Implicit link to <a href="https://keplerproject.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.symlinkattributes</code></a>
+ Implicit link to <a href="https://lunarmodules.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.symlinkattributes</code></a>
 
 
 
@@ -371,7 +371,7 @@
     Changes the working directory.
  On Windows, if a drive is specified, it also changes the current drive. If
  only specifying the drive, it will only switch drive, but not modify the path.
- Implicit link to <a href="https://keplerproject.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.chdir</code></a>
+ Implicit link to <a href="https://lunarmodules.github.io/luafilesystem/manual.html#reference"><code>luafilesystem.chdir</code></a>
 
 
 

--- a/docs/manual/01-introduction.md.html
+++ b/docs/manual/01-introduction.md.html
@@ -168,7 +168,7 @@ the order, so that the function is passed the value and then the key. Although
 perverse, this matches the intended use better.</p>
 
 <p>The only important external dependence of Penlight is
-<a href="http://keplerproject.github.com/luafilesystem/manual.html">LuaFileSystem</a>
+<a href="http://lunarmodules.github.io/luafilesystem/manual.html">LuaFileSystem</a>
 (<a href="http://stevedonovan.github.io/lua-stdlibs/lfs.html">lfs</a>), and if you want <a href="../libraries/pl.dir.html#copyfile">dir.copyfile</a> to work cleanly on Windows, you will need
 either <a href="http://alien.luaforge.net/">alien</a> or be using
 <a href="http://luajit.org">LuaJIT</a> as well. (The fallback is to call the equivalent


### PR DESCRIPTION
keplerproject.github.io/luafilesystem no longer exists, so those links currently return 404 instead of pointing to the docs for luafilesystem