### PR TITLE
fix(*): some more Lua 5.5 fixes for constant loop variables

### DIFF
--- a/lua/pl/app.lua
+++ b/lua/pl/app.lua
@@ -208,8 +208,9 @@ function app.parse_args (args,flags_with_values, flags_valid)
     else
         valid = {}
         for k,aliases in pairs(flags_valid) do
+            local key = k
             if type(k) == "number" then         -- array/list entry
-                k = aliases
+                key = aliases
             end
             if type(aliases) == "string" then  -- single alias
                 aliases = { aliases }
@@ -217,10 +218,10 @@ function app.parse_args (args,flags_with_values, flags_valid)
             if type(aliases) == "table" then   -- list of aliases
                 -- it's the alternate name, so add the proper mappings
                 for i, alias in ipairs(aliases) do
-                    valid[alias] = k
+                    valid[alias] = key
                 end
             end
-            valid[k] = k
+            valid[key] = key
         end
         do
             local new_with_values = {}  -- needed to prevent "invalid key to 'next'" error

--- a/lua/pl/seq.lua
+++ b/lua/pl/seq.lua
@@ -295,13 +295,14 @@ function seq.printall(iter,sep,nfields,fmt)
   end
   local k = 1
   for v in default_iter(iter) do
-     if fmt then v = fmt(v) end
-     if k < nfields then
-       write(v,sep)
-       k = k + 1
+    local value = v
+    if fmt then value = fmt(v) end
+    if k < nfields then
+      write(value,sep)
+      k = k + 1
     else
-       write(v,'\n')
-       k = 1
+      write(value,'\n')
+      k = 1
     end
   end
   write '\n'


### PR DESCRIPTION
Here are some more Lua 5.5 loop constant fixes.
The tests now look the same for me with a local build of Lua 5.5 beta as
with Lua 5.{1..4}.
